### PR TITLE
feat(backend): 技判定スコア計算APIを追加

### DIFF
--- a/services/backend/docs/score-calculation-api.md
+++ b/services/backend/docs/score-calculation-api.md
@@ -1,0 +1,66 @@
+# Score Calculation API Spec
+
+## Purpose
+フロントから受け取った判定結果（Perfect / Good / Bad）を使って、
+バックエンドでスコアを計算し、保存せずにレスポンスとして返す。
+
+## Endpoint
+- Method: `POST`
+- Path: `/api/scores/calculate`
+- Auth: 不要（公開API）
+- Persistence: なし（DB保存しない）
+
+## Request
+### Body
+```json
+{
+  "perfect": 10,
+  "good": 5,
+  "bad": 2
+}
+```
+
+### Field Rules
+- `perfect`: integer, 0以上
+- `good`: integer, 0以上
+- `bad`: integer, 0以上
+
+## Scoring Rules
+- Perfect: `100` 点
+- Good: `50` 点
+- Bad: `0` 点
+
+### Formula
+`totalScore = perfect * 100 + good * 50 + bad * 0`
+
+## Response
+### 200 OK
+```json
+{
+  "totalScore": 1250,
+  "counts": {
+    "perfect": 10,
+    "good": 5,
+    "bad": 2
+  },
+  "points": {
+    "perfect": 100,
+    "good": 50,
+    "bad": 0
+  }
+}
+```
+
+## Error Cases
+- `400 Bad Request`
+  - 必須項目不足
+  - 負数の入力
+  - 数値以外の入力
+
+## Frontend Usage Flow
+1. プレイ終了時に判定件数を集計
+2. `/api/scores/calculate` に `perfect/good/bad` を送信
+3. `totalScore` をリザルト画面に表示
+
+## Future Work
+- スコア計算結果をクラウドに保存する

--- a/services/backend/src/main/java/com/happykaratesoup/backend/config/SecurityConfig.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/config/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/admin/**").authenticated()
-                        .requestMatchers("/api/charts/**", "/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
+                    .requestMatchers("/api/charts/**", "/api/scores/**", "/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                         .anyRequest().permitAll())
                 .httpBasic(Customizer.withDefaults());
 

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationController.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationController.java
@@ -1,0 +1,25 @@
+package com.happykaratesoup.backend.score;
+
+import com.happykaratesoup.backend.score.model.ScoreCalculationRequest;
+import com.happykaratesoup.backend.score.model.ScoreCalculationResponse;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/scores")
+public class ScoreCalculationController {
+
+    private final ScoreCalculationService scoreCalculationService;
+
+    public ScoreCalculationController(ScoreCalculationService scoreCalculationService) {
+        this.scoreCalculationService = scoreCalculationService;
+    }
+
+    @PostMapping("/calculate")
+    public ScoreCalculationResponse calculate(@Valid @RequestBody ScoreCalculationRequest request) {
+        return scoreCalculationService.calculate(request);
+    }
+}

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationService.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationService.java
@@ -1,0 +1,35 @@
+package com.happykaratesoup.backend.score;
+
+import com.happykaratesoup.backend.score.model.ScoreCalculationRequest;
+import com.happykaratesoup.backend.score.model.ScoreCalculationResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class ScoreCalculationService {
+
+    private static final int PERFECT_POINT = 100;
+    private static final int GOOD_POINT = 50;
+    private static final int BAD_POINT = 0;
+
+    public ScoreCalculationResponse calculate(ScoreCalculationRequest request) {
+        int totalScore = request.perfect() * PERFECT_POINT
+                + request.good() * GOOD_POINT
+                + request.bad() * BAD_POINT;
+
+        return new ScoreCalculationResponse(
+                totalScore,
+                Map.of(
+                        "perfect", request.perfect(),
+                        "good", request.good(),
+                        "bad", request.bad()
+                ),
+                Map.of(
+                        "perfect", PERFECT_POINT,
+                        "good", GOOD_POINT,
+                        "bad", BAD_POINT
+                )
+        );
+    }
+}

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationRequest.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationRequest.java
@@ -1,0 +1,11 @@
+package com.happykaratesoup.backend.score.model;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ScoreCalculationRequest(
+        @NotNull @Min(0) Integer perfect,
+        @NotNull @Min(0) Integer good,
+        @NotNull @Min(0) Integer bad
+) {
+}

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationResponse.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationResponse.java
@@ -1,0 +1,10 @@
+package com.happykaratesoup.backend.score.model;
+
+import java.util.Map;
+
+public record ScoreCalculationResponse(
+        int totalScore,
+        Map<String, Integer> counts,
+        Map<String, Integer> points
+) {
+}

--- a/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationControllerTest.java
+++ b/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationControllerTest.java
@@ -1,0 +1,52 @@
+package com.happykaratesoup.backend.score;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ScoreCalculationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnCalculatedScore() throws Exception {
+        mockMvc.perform(post("/api/scores/calculate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "perfect": 5,
+                                  "good": 2,
+                                  "bad": 1
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalScore").value(600))
+                .andExpect(jsonPath("$.counts.perfect").value(5))
+                .andExpect(jsonPath("$.counts.good").value(2))
+                .andExpect(jsonPath("$.counts.bad").value(1));
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenNegativeInputIsSent() throws Exception {
+        mockMvc.perform(post("/api/scores/calculate")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "perfect": -1,
+                                  "good": 2,
+                                  "bad": 1
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationServiceTest.java
+++ b/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationServiceTest.java
@@ -1,0 +1,27 @@
+package com.happykaratesoup.backend.score;
+
+import com.happykaratesoup.backend.score.model.ScoreCalculationRequest;
+import com.happykaratesoup.backend.score.model.ScoreCalculationResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ScoreCalculationServiceTest {
+
+    private final ScoreCalculationService service = new ScoreCalculationService();
+
+    @Test
+    void shouldCalculateScoreByJudgementCounts() {
+        ScoreCalculationRequest request = new ScoreCalculationRequest(3, 2, 4);
+
+        ScoreCalculationResponse response = service.calculate(request);
+
+        assertEquals(400, response.totalScore());
+        assertEquals(3, response.counts().get("perfect"));
+        assertEquals(2, response.counts().get("good"));
+        assertEquals(4, response.counts().get("bad"));
+        assertEquals(100, response.points().get("perfect"));
+        assertEquals(50, response.points().get("good"));
+        assertEquals(0, response.points().get("bad"));
+    }
+}


### PR DESCRIPTION
POST /api/scores/calculate を追加

Perfect/Good/Bad の件数を受け取り、100/50/0 点で合計スコアを計算して返却

計算結果は保存せずレスポンスのみ返す

フロントは各アクションを Perfect/Good/Bad で判定し、プレイ終了時に件数を集計して送信する

呼び出しフロー: 画面側で判定集計 -> /api/scores/calculate にPOST -> totalScoreをリザルト表示