### PR TITLE
vertexAIをデフォルトで使うようにymlを設定

### DIFF
--- a/apps/web/backend-java/src/main/resources/application.yml
+++ b/apps/web/backend-java/src/main/resources/application.yml
@@ -8,11 +8,11 @@ spring:
 gemini:
   api-key: ${GEMINI_API_KEY:}
   base-url: https://generativelanguage.googleapis.com
-  use-vertex-ai: ${GEMINI_USE_VERTEX_AI:false}
+  use-vertex-ai: ${GEMINI_USE_VERTEX_AI:true}
   project-id: ${GEMINI_PROJECT_ID:}
-  location: ${GEMINI_LOCATION:asia-northeast1}
-  text-model: ${GEMINI_TEXT_MODEL:gemini-3-flash-preview}
-  image-model: ${GEMINI_IMAGE_MODEL:gemini-3-pro-image-preview}
+  location: ${GEMINI_LOCATION:us-central1}
+  text-model: ${GEMINI_TEXT_MODEL:gemini-2.5-flash}
+  image-model: ${GEMINI_IMAGE_MODEL:gemini-2.5-flash-image}
 
 app:
   cors:


### PR DESCRIPTION
- 普通にやると2.5モデルしか使えなそう
- 3.0のモデルを使う方法もありそうだが、3.0より2.5の方が良さげな気もする
- regionによって使えるモデルの種類が異なる。us-central1 なら割と最新のも使える