### PR TITLE
feat(backend): スコア計算APIを新しい入力形式に対応し、レスポンスをtotalScoreのみに変更

### DIFF
--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationController.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationController.java
@@ -8,16 +8,39 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST Controller for score calculation API endpoints.
+ * Handles POST requests to calculate game scores from judgment data.
+ * 
+ * スコア計算APIエンドポイントのRESTコントローラー
+ * 判定データからゲームスコアを計算するPOSTリクエストを処理します。
+ */
 @RestController
 @RequestMapping("/api/scores")
 public class ScoreCalculationController {
 
     private final ScoreCalculationService scoreCalculationService;
 
+    /**
+     * Constructor for dependency injection of ScoreCalculationService.
+     * スコア計算サービスのコンストラクタ注入
+     */
     public ScoreCalculationController(ScoreCalculationService scoreCalculationService) {
         this.scoreCalculationService = scoreCalculationService;
     }
 
+    /**
+     * POST endpoint to calculate score from judgment data.
+     * Endpoint: POST /api/scores/calculate
+     * 
+     * 判定データからスコアを計算するPOSTエンドポイント
+     * エンドポイント: POST /api/scores/calculate
+     * 
+     * @param request validated score calculation request with judgment counts
+     *                判定カウントを含む検証済みスコア計算リクエスト
+     * @return ScoreCalculationResponse with totalScore and breakdown
+     *         totalScoreとその内訳を含むレスポンス
+     */
     @PostMapping("/calculate")
     public ScoreCalculationResponse calculate(@Valid @RequestBody ScoreCalculationRequest request) {
         return scoreCalculationService.calculate(request);

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationService.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationService.java
@@ -4,32 +4,48 @@ import com.happykaratesoup.backend.score.model.ScoreCalculationRequest;
 import com.happykaratesoup.backend.score.model.ScoreCalculationResponse;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-
+/**
+ * Service class for calculating game scores based on judgment results.
+ * ゲームの判定結果に基づいてスコアを計算するサービスクラス
+ */
 @Service
 public class ScoreCalculationService {
 
+    // Point values for each judgment type
+    // 各判定タイプのポイント値
     private static final int PERFECT_POINT = 100;
     private static final int GOOD_POINT = 50;
-    private static final int BAD_POINT = 0;
+    private static final int OK_POINT = 25;
+    private static final int MISS_POINT = 0;
 
+    /**
+     * Calculates the total score from judgment counts.
+     * Multiplies each judgment type by its point value and sums them up.
+     * 
+     * 判定結果からスコアを計算します。
+     * 各判定タイプをそのポイント値で乗算し、合計を算出します。
+     * 
+     * @param request contains score data with max_combo and judgment counts
+     *                (max_combo と判定カウントを含むスコアデータ)
+     * @return response containing totalScore
+     *         (totalScoreを含むレスポンス)
+     */
     public ScoreCalculationResponse calculate(ScoreCalculationRequest request) {
-        int totalScore = request.perfect() * PERFECT_POINT
-                + request.good() * GOOD_POINT
-                + request.bad() * BAD_POINT;
+        // Extract score data and judgment counts from the request
+        // リクエストからスコアデータと判定カウントを抽出
+        var scoreData = request.scoreData();
+        var judgments = scoreData.judgments();
 
-        return new ScoreCalculationResponse(
-                totalScore,
-                Map.of(
-                        "perfect", request.perfect(),
-                        "good", request.good(),
-                        "bad", request.bad()
-                ),
-                Map.of(
-                        "perfect", PERFECT_POINT,
-                        "good", GOOD_POINT,
-                        "bad", BAD_POINT
-                )
-        );
+        // Calculate total score by multiplying each judgment count by its point value
+        // 各判定カウントにそのポイント値を乗算してスコアを合計
+        // Formula: totalScore = perfect*100 + good*50 + ok*25 + miss*0
+        int totalScore = judgments.perfect() * PERFECT_POINT
+                + judgments.good() * GOOD_POINT
+                + judgments.ok() * OK_POINT
+                + judgments.miss() * MISS_POINT;
+
+        // Return response with total score
+        // totalScoreを含むレスポンスを返却
+        return new ScoreCalculationResponse(totalScore);
     }
 }

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/model/Judgments.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/model/Judgments.java
@@ -1,0 +1,21 @@
+package com.happykaratesoup.backend.score.model;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Record representing judgment counts from a game play.
+ * Contains counts for each judgment type: perfect, good, ok, and miss.
+ * All counts must be non-negative integers (>= 0).
+ * 
+ * ゲームプレイの判定カウントを表すレコード
+ * 各判定タイプのカウント数を含みます: perfect、good、ok、miss
+ * すべてのカウント値は非負整数（>= 0）である必要があります。
+ */
+public record Judgments(
+        @NotNull @Min(0) Integer perfect,
+        @NotNull @Min(0) Integer good,
+        @NotNull @Min(0) Integer ok,
+        @NotNull @Min(0) Integer miss
+) {
+}

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationRequest.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationRequest.java
@@ -1,11 +1,18 @@
 package com.happykaratesoup.backend.score.model;
 
-import jakarta.validation.constraints.Min;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
+/**
+ * Record for score calculation request.
+ * Accepts game play data including max combo and judgment counts.
+ * 
+ * スコア計算リクエスト用レコード
+ * 最大コンボ数と判定カウントを含むゲームプレイデータを受け取ります。
+ */
 public record ScoreCalculationRequest(
-        @NotNull @Min(0) Integer perfect,
-        @NotNull @Min(0) Integer good,
-        @NotNull @Min(0) Integer bad
+        @JsonProperty("score_data")
+        @Valid @NotNull ScoreData scoreData
 ) {
 }

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationResponse.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationResponse.java
@@ -1,10 +1,16 @@
 package com.happykaratesoup.backend.score.model;
 
-import java.util.Map;
-
+/**
+ * Record for score calculation response.
+ * Provides the calculated total score.
+ * 
+ * スコア計算レスポンス用レコード
+ * 計算されたトータルスコアを提供します。
+ * 
+ * @param totalScore the sum of all judgment points
+ *                   すべての判定ポイントの合計
+ */
 public record ScoreCalculationResponse(
-        int totalScore,
-        Map<String, Integer> counts,
-        Map<String, Integer> points
+        int totalScore
 ) {
 }

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreData.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreData.java
@@ -1,0 +1,22 @@
+package com.happykaratesoup.backend.score.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Record containing game performance metrics.
+ * Includes maximum combo count and judgment type counts.
+ * JSON property: "max_combo" maps to maxCombo field
+ * 
+ * ゲームパフォーマンスメトリクスを含むレコード
+ * 最大コンボ数と判定タイプのカウント数を含みます。
+ * JSONプロパティ: "max_combo" は maxCombo フィールドにマップされます
+ */
+public record ScoreData(
+        @JsonProperty("max_combo")
+        @NotNull @Min(0) Integer maxCombo,
+        @Valid @NotNull Judgments judgments
+) {
+}

--- a/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationControllerTest.java
+++ b/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationControllerTest.java
@@ -11,6 +11,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Integration tests for ScoreCalculationController.
+ * Tests HTTP endpoints for score calculation API.
+ * 
+ * ScoreCalculationControllerの統合テスト
+ * スコア計算APIのHTTPエンドポイントをテストします。
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 class ScoreCalculationControllerTest {
@@ -18,35 +25,73 @@ class ScoreCalculationControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    /**
+     * Test: Successful score calculation request.
+     * Sends a valid JSON request with judgment data and verifies the score response.
+     * Expected: HTTP 200 OK with calculated totalScore of 4125
+     * 
+     * テスト: スコア計算リクエストの成功ケース
+     * 判定データを含む有効なJSONリクエストを送信し、スコアレスポンスを検証します。
+     * 期待値: HTTP 200 OK、calculated totalScore = 4125
+     */
     @Test
     void shouldReturnCalculatedScore() throws Exception {
+        // Send POST request to /api/scores/calculate endpoint
+        // /api/scores/calculate エンドポイントへPOSTリクエストを送信
         mockMvc.perform(post("/api/scores/calculate")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "perfect": 5,
-                                  "good": 2,
-                                  "bad": 1
+                                  "score_data": {
+                                    "max_combo": 42,
+                                    "judgments": {
+                                      "perfect": 35,
+                                      "good": 10,
+                                      "ok": 5,
+                                      "miss": 2
+                                    }
+                                  }
                                 }
                                 """))
+                // Verify HTTP status is 200 OK
+                // HTTPステータスが200 OKであることを検証
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalScore").value(600))
-                .andExpect(jsonPath("$.counts.perfect").value(5))
-                .andExpect(jsonPath("$.counts.good").value(2))
-                .andExpect(jsonPath("$.counts.bad").value(1));
+                // Verify calculated totalScore is 4125
+                // 計算されたtotalScoreが4125であることを検証
+                .andExpect(jsonPath("$.totalScore").value(4125));
     }
 
+    /**
+     * Test: Validation error when negative input is sent.
+     * Sends a request with negative perfect count and expects validation failure.
+     * Expected: HTTP 400 Bad Request
+     * 
+     * テスト: 負の値が送信されたときの検証エラー
+     * perfectカウントが負の値を含むリクエストを送信し、検証失敗を期待します。
+     * 期待値: HTTP 400 Bad Request
+     */
     @Test
     void shouldReturnBadRequestWhenNegativeInputIsSent() throws Exception {
+        // Send POST request with invalid negative value for perfect judgment
+        // perfectの判定にマイナスの値を含むPOSTリクエストを送信
         mockMvc.perform(post("/api/scores/calculate")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "perfect": -1,
-                                  "good": 2,
-                                  "bad": 1
+                                  "score_data": {
+                                    "max_combo": 42,
+                                    "judgments": {
+                                      "perfect": -1,
+                                      "good": 10,
+                                      "ok": 5,
+                                      "miss": 2
+                                    }
+                                  }
                                 }
                                 """))
+                // Verify validation fails and returns 400 Bad Request
+                // バリデーション失敗により400 Bad Requestが返されることを検証
                 .andExpect(status().isBadRequest());
     }
 }
+

--- a/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationServiceTest.java
+++ b/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationServiceTest.java
@@ -6,22 +6,48 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * Unit tests for ScoreCalculationService.
+ * Tests the score calculation logic with various judgment count combinations.
+ * 
+ * ScoreCalculationServiceの単体テスト
+ * 様々な判定カウントの組み合わせでスコア計算ロジックをテストします。
+ */
 class ScoreCalculationServiceTest {
 
     private final ScoreCalculationService service = new ScoreCalculationService();
 
+    /**
+     * Test: Verify score calculation with sample judgment data.
+     * Input: perfect=35, good=10, ok=5, miss=2, max_combo=42
+     * Expected: totalScore = 35*100 + 10*50 + 5*25 + 2*0 = 4125
+     * 
+     * テスト: サンプル判定データでのスコア計算を検証
+     * 入力: perfect=35, good=10, ok=5, miss=2, max_combo=42
+     * 期待値: totalScore = 35*100 + 10*50 + 5*25 + 2*0 = 4125
+     */
     @Test
     void shouldCalculateScoreByJudgementCounts() {
-        ScoreCalculationRequest request = new ScoreCalculationRequest(3, 2, 4);
+        // Create judgment data for test: 35 perfect, 10 good, 5 ok, 2 miss
+        // テスト用の判定データを作成: 35 perfect, 10 good, 5 ok, 2 miss
+        var judgments = new com.happykaratesoup.backend.score.model.Judgments(35, 10, 5, 2);
+        
+        // Create score data with max combo and judgments
+        // スコアデータを作成（最大コンボ数と判定データ）
+        var scoreData = new com.happykaratesoup.backend.score.model.ScoreData(42, judgments);
+        
+        // Create the request object
+        // リクエストオブジェクトを作成
+        ScoreCalculationRequest request = new ScoreCalculationRequest(scoreData);
 
+        // Execute score calculation
+        // スコア計算を実行
         ScoreCalculationResponse response = service.calculate(request);
 
-        assertEquals(400, response.totalScore());
-        assertEquals(3, response.counts().get("perfect"));
-        assertEquals(2, response.counts().get("good"));
-        assertEquals(4, response.counts().get("bad"));
-        assertEquals(100, response.points().get("perfect"));
-        assertEquals(50, response.points().get("good"));
-        assertEquals(0, response.points().get("bad"));
+        // Verify total score: 35*100 + 10*50 + 5*25 + 2*0 = 4125
+        // トータルスコアを検証: 35*100 + 10*50 + 5*25 + 2*0 = 4125
+        assertEquals(4125, response.totalScore());
     }
 }
+
+


### PR DESCRIPTION
変更内容:

- リクエスト形式を score_data { max_combo, judgments { perfect, good, ok, miss } } に対応

- score_data / max_combo のスネークケースJSONをマッピング対応

- 判定ごとの点数を適用（perfect=100, good=50, ok=25, miss=0）

- レスポンスを totalScore のみ返す仕様に変更

- score関連コードとテストに英語/日本語コメントを追加

- 新形式に合わせてController/Serviceテストを更新

API呼び出し:

POST /api/scores/calculate

Request: {"score_data":{"max_combo":42,"judgments":{"perfect":35,"good":10,"ok":5,"miss":2}}}

Response: {"totalScore":4125}