### PR TITLE
ランク機能を実装・スコア計算にコンボボーナスを統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ logs/
 **/node_modules/
 **/dist/
 **/dist-ssr/
+
+target/
+**/target/

--- a/apps/web/src/api/scoreApi.ts
+++ b/apps/web/src/api/scoreApi.ts
@@ -14,6 +14,7 @@ export type ScoreCalculateRequest = {
 
 export type ScoreCalculateResponse = {
   totalScore: number;
+  rank: string; // [EN] Rank from backend calculation (S/A/B/C). [JA] バックエンド計算からのランク（S/A/B/C）
 };
 
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080').replace(/\/$/, '');

--- a/apps/web/src/pages/Game/Game.tsx
+++ b/apps/web/src/pages/Game/Game.tsx
@@ -86,7 +86,7 @@ export default function Game() {
   const soupGenerationPromiseRef = useRef<Promise<SoupGenerateResponse> | null>(null);
   const soupGenerationResultRef = useRef<SoupGenerateResponse | null>(null);
   // フックから必要な状態を受け取る
-  const { phase, count, ingredients, removeIngredient, submitScore, totalScore, isChartFlowFinished } = useGameLogic({
+  const { phase, count, ingredients, removeIngredient, submitScore, totalScore, rank, isChartFlowFinished } = useGameLogic({
     selectedIngredientEmojis,
   });
 
@@ -210,9 +210,11 @@ export default function Game() {
       // [EN] Score API failure should not block result navigation.
       // [JA] score API が失敗しても、リザルト遷移は止めません。
       let resolvedTotalScore = totalScore ?? 0;
+      let resolvedRank = rank ?? 'C'; // [EN] Fallback rank if not set. [JA] ランクが未設定の場合のフォールバック
       try {
         const scoreResponse = await submitScore();
         resolvedTotalScore = scoreResponse.totalScore;
+        resolvedRank = scoreResponse.rank; // [EN] Get rank from API response. [JA] API レスポンスからランク取得
         sessionStorage.setItem('latestScoreResult', JSON.stringify(scoreResponse));
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to submit score';
@@ -229,6 +231,7 @@ export default function Game() {
         flavor: FALLBACK_FLAVOR,
         comment: FALLBACK_COMMENT,
         totalScore: resolvedTotalScore,
+        rank: resolvedRank, // [EN] Add rank to result. [JA] 結果にランクを追加
       };
 
       sessionStorage.setItem('latestSoupResult', JSON.stringify(resultData));

--- a/apps/web/src/pages/Game/useGameLogic.ts
+++ b/apps/web/src/pages/Game/useGameLogic.ts
@@ -54,6 +54,7 @@ export const useGameLogic = (options: UseGameLogicOptions = {}) => {
     processJudgment,
     submitScore,
     totalScore,
+    rank,
     isSubmittingScore,
     scoreSubmitError,
   } = useScoreLogic();
@@ -221,6 +222,7 @@ export const useGameLogic = (options: UseGameLogicOptions = {}) => {
     scoreData,
     submitScore,
     totalScore,
+    rank,
     isSubmittingScore,
     scoreSubmitError,
     isChartFlowFinished,

--- a/apps/web/src/pages/Game/useScoreLogic.tsx
+++ b/apps/web/src/pages/Game/useScoreLogic.tsx
@@ -8,6 +8,7 @@ export const useScoreLogic = () => {
   const [combo, setCombo] = useState(0); // コンボ数を管理する状態
   const [maxCombo, setMaxCombo] = useState(0); // 最大コンボ数を管理する状態
   const [totalScore, setTotalScore] = useState<number | null>(null); // APIから返るtotalScore
+  const [rank, setRank] = useState<string | null>(null); // [EN] Rank from backend. [JA] バックエンドから返るランク
   const [isSubmittingScore, setIsSubmittingScore] = useState(false); // 送信中フラグ
   const [scoreSubmitError, setScoreSubmitError] = useState<string | null>(null); // 送信エラー
   const [judgments, setJudgments] = useState({ // 判定結果を管理する状態
@@ -69,8 +70,8 @@ export const useScoreLogic = () => {
     }
   };
 
-  // [EN] Sends current score data to backend and stores returned totalScore.
-  // [JA] 現在のスコアデータをバックエンドへ送信し、返却された totalScore を保持します。
+  // [EN] Sends current score data to backend and stores returned totalScore and rank.
+  // [JA] 現在のスコアデータをバックエンドへ送信し、返却された totalScore と rank を保持します。
   const submitScore = useCallback(async () => {
     setIsSubmittingScore(true);
     setScoreSubmitError(null);
@@ -84,6 +85,7 @@ export const useScoreLogic = () => {
       });
 
       setTotalScore(response.totalScore);
+      setRank(response.rank); // [EN] Store rank from response. [JA] レスポンスからランクを保持
       return response;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to submit score';
@@ -100,6 +102,7 @@ export const useScoreLogic = () => {
     processJudgment,
     submitScore,
     totalScore,
+    rank, // [EN] Rank from backend score calculation. [JA] バックエンド採点からのランク
     isSubmittingScore,
     scoreSubmitError,
   };

--- a/apps/web/src/pages/Result/Result.tsx
+++ b/apps/web/src/pages/Result/Result.tsx
@@ -12,6 +12,7 @@ import type { SoupGenerateResponse } from '../../api/soupApi';
 
 type ResultData = SoupGenerateResponse & {
   totalScore?: number;
+  rank?: string; // [EN] Rank from score calculation. [JA] 採点計算からのランク
 };
 
 type ResultLocationState = { // 生成結果とエラー情報を格納する型
@@ -31,7 +32,7 @@ export default function Result() {
   const storedResultData = sessionStorage.getItem('latestResultData');
   const storedSoup = sessionStorage.getItem('latestSoupResult');
   const storedScore = sessionStorage.getItem('latestScoreResult');
-  const parsedStoredScore = storedScore ? (JSON.parse(storedScore) as { totalScore?: number }) : null;
+  const parsedStoredScore = storedScore ? (JSON.parse(storedScore) as { totalScore?: number; rank?: string }) : null;
   const storedResult = storedResultData
     ? (JSON.parse(storedResultData) as ResultData)
     : storedSoup
@@ -39,6 +40,7 @@ export default function Result() {
       : null;
   const result = state?.generated ?? storedResult;
   const scoreValue = result?.totalScore ?? state?.score ?? parsedStoredScore?.totalScore ?? 0;
+  const rankValue = result?.rank ?? parsedStoredScore?.rank ?? 'C'; // [EN] Fallback to 'C'. [JA] 取得できない場合は 'C'
 
   const comment = result?.comment ?? 'コメントはまだ生成されていません。';
   const imageDataUrl = result?.imageDataUrl ?? '';
@@ -62,7 +64,7 @@ export default function Result() {
         </div>
 
         <div style={{ textAlign: 'left' }}>
-          <h2 style={{ color: '#ff9800' }}>ランク: S</h2>
+          <h2 style={{ color: '#ff9800' }}>ランク: {rankValue}</h2>
           <p>スコア: {scoreValue} Gpt</p>
           {result?.flavor ? (
             <FlavorRadarChart flavor={result.flavor} size={300} />

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationService.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/ScoreCalculationService.java
@@ -18,6 +18,16 @@ public class ScoreCalculationService {
     private static final int OK_POINT = 25;
     private static final int MISS_POINT = 0;
 
+    // [EN] Combo bonus points per combo (10pts per combo).
+    // [JA] コンボボーナス（1コンボあたり10点）
+    private static final int COMBO_BONUS = 10;
+
+    // [EN] Rank thresholds based on total score (including combo bonus).
+    // [JA] ランク基準（コンボボーナス含む）
+    private static final int RANK_S_THRESHOLD = 1800;
+    private static final int RANK_A_THRESHOLD = 1400;
+    private static final int RANK_B_THRESHOLD = 900;
+
     /**
      * Calculates the total score from judgment counts.
      * Multiplies each judgment type by its point value and sums them up.
@@ -36,16 +46,39 @@ public class ScoreCalculationService {
         var scoreData = request.scoreData();
         var judgments = scoreData.judgments();
 
-        // Calculate total score by multiplying each judgment count by its point value
-        // 各判定カウントにそのポイント値を乗算してスコアを合計
-        // Formula: totalScore = perfect*100 + good*50 + ok*25 + miss*0
-        int totalScore = judgments.perfect() * PERFECT_POINT
+        // [EN] Calculate base score by multiplying each judgment count by its point value.
+        // [JA] 各判定カウントにそのポイント値を乗算してベーススコアを合計
+        // Formula: base = perfect*100 + good*50 + ok*25 + miss*0
+        int baseScore = judgments.perfect() * PERFECT_POINT
                 + judgments.good() * GOOD_POINT
                 + judgments.ok() * OK_POINT
                 + judgments.miss() * MISS_POINT;
 
-        // Return response with total score
-        // totalScoreを含むレスポンスを返却
-        return new ScoreCalculationResponse(totalScore);
+        // [EN] Add combo bonus: 10 points per completed combo.
+        // [JA] コンボボーナスを加算（1コンボあたり10点）
+        int comboBonus = scoreData.maxCombo() * COMBO_BONUS;
+        int totalScore = baseScore + comboBonus;
+
+        // [EN] Calculate rank based on total score.
+        // [JA] 総スコアに基づいてランクを計算
+        String rank = calculateRank(totalScore);
+
+        // Return response with total score and rank
+        // totalScore とランクを含むレスポンスを返却
+        return new ScoreCalculationResponse(totalScore, rank);
+    }
+
+    // [EN] Determines rank from total score.
+    // [JA] 総スコアからランクを判定します
+    private String calculateRank(int totalScore) {
+        if (totalScore >= RANK_S_THRESHOLD) {
+            return "S";
+        } else if (totalScore >= RANK_A_THRESHOLD) {
+            return "A";
+        } else if (totalScore >= RANK_B_THRESHOLD) {
+            return "B";
+        } else {
+            return "C";
+        }
     }
 }

--- a/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationResponse.java
+++ b/services/backend/src/main/java/com/happykaratesoup/backend/score/model/ScoreCalculationResponse.java
@@ -11,6 +11,7 @@ package com.happykaratesoup.backend.score.model;
  *                   すべての判定ポイントの合計
  */
 public record ScoreCalculationResponse(
-        int totalScore
+        int totalScore,
+        String rank
 ) {
 }

--- a/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationControllerTest.java
+++ b/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationControllerTest.java
@@ -26,13 +26,13 @@ class ScoreCalculationControllerTest {
     private MockMvc mockMvc;
 
     /**
-     * Test: Successful score calculation request.
-     * Sends a valid JSON request with judgment data and verifies the score response.
-     * Expected: HTTP 200 OK with calculated totalScore of 4125
+     * Test: Successful score calculation request with combo bonus and rank.
+     * Sends a valid JSON request with judgment data and verifies the score + rank response.
+     * Expected: HTTP 200 OK with calculated totalScore of 4545 (4125 base + 420 bonus) and rank S
      * 
-     * テスト: スコア計算リクエストの成功ケース
-     * 判定データを含む有効なJSONリクエストを送信し、スコアレスポンスを検証します。
-     * 期待値: HTTP 200 OK、calculated totalScore = 4125
+     * テスト: スコア計算リクエストの成功ケース（コンボボーナス＆ランク含む）
+     * 判定データを含む有効なJSONリクエストを送信し、スコアとランクレスポンスを検証します。
+     * 期待値: HTTP 200 OK、totalScore = 4545（4125ベース + 420ボーナス）、rank = S
      */
     @Test
     void shouldReturnCalculatedScore() throws Exception {
@@ -56,9 +56,12 @@ class ScoreCalculationControllerTest {
                 // Verify HTTP status is 200 OK
                 // HTTPステータスが200 OKであることを検証
                 .andExpect(status().isOk())
-                // Verify calculated totalScore is 4125
-                // 計算されたtotalScoreが4125であることを検証
-                .andExpect(jsonPath("$.totalScore").value(4125));
+                // [EN] Verify calculated totalScore = base (4125) + combo bonus (42*10=420) = 4545
+                // [JA] 計算されたtotalScore = ベース（4125）+ コンボボーナス（42*10=420）= 4545
+                .andExpect(jsonPath("$.totalScore").value(4545))
+                // [EN] Verify rank is S (score >= 1800)
+                // [JA] ランクが S（スコア >= 1800）であることを検証
+                .andExpect(jsonPath("$.rank").value("S"));
     }
 
     /**

--- a/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationServiceTest.java
+++ b/services/backend/src/test/java/com/happykaratesoup/backend/score/ScoreCalculationServiceTest.java
@@ -20,11 +20,15 @@ class ScoreCalculationServiceTest {
     /**
      * Test: Verify score calculation with sample judgment data.
      * Input: perfect=35, good=10, ok=5, miss=2, max_combo=42
-     * Expected: totalScore = 35*100 + 10*50 + 5*25 + 2*0 = 4125
+     * Expected: baseScore = 35*100 + 10*50 + 5*25 + 2*0 = 4125
+     *           comboBonus = 42*10 = 420
+     *           totalScore = 4125 + 420 = 4545 (Rank S)
      * 
      * テスト: サンプル判定データでのスコア計算を検証
      * 入力: perfect=35, good=10, ok=5, miss=2, max_combo=42
-     * 期待値: totalScore = 35*100 + 10*50 + 5*25 + 2*0 = 4125
+     * 期待値: baseScore = 35*100 + 10*50 + 5*25 + 2*0 = 4125
+     *        comboBonus = 42*10 = 420
+     *        totalScore = 4125 + 420 = 4545（ランク S）
      */
     @Test
     void shouldCalculateScoreByJudgementCounts() {
@@ -44,9 +48,62 @@ class ScoreCalculationServiceTest {
         // スコア計算を実行
         ScoreCalculationResponse response = service.calculate(request);
 
-        // Verify total score: 35*100 + 10*50 + 5*25 + 2*0 = 4125
-        // トータルスコアを検証: 35*100 + 10*50 + 5*25 + 2*0 = 4125
-        assertEquals(4125, response.totalScore());
+        // Verify total score: 35*100 + 10*50 + 5*25 + 2*0 + 42*10 = 4545
+        // トータルスコアを検証: 35*100 + 10*50 + 5*25 + 2*0 + 42*10 = 4545
+        assertEquals(4545, response.totalScore());
+        assertEquals("S", response.rank());
+    }
+
+    // [EN] Test rank calculation: score 1800+ should be rank S.
+    // [JA] テスト: スコア1800以上はランク S
+    @Test
+    void shouldCalculateRankS() {
+        var judgments = new com.happykaratesoup.backend.score.model.Judgments(18, 0, 0, 2);
+        var scoreData = new com.happykaratesoup.backend.score.model.ScoreData(0, judgments);
+        ScoreCalculationRequest request = new ScoreCalculationRequest(scoreData);
+        
+        ScoreCalculationResponse response = service.calculate(request);
+        assertEquals(1800, response.totalScore());
+        assertEquals("S", response.rank());
+    }
+
+    // [EN] Test rank calculation: score 1400-1799 should be rank A.
+    // [JA] テスト: スコア1400～1799はランク A
+    @Test
+    void shouldCalculateRankA() {
+        var judgments = new com.happykaratesoup.backend.score.model.Judgments(14, 0, 0, 6);
+        var scoreData = new com.happykaratesoup.backend.score.model.ScoreData(0, judgments);
+        ScoreCalculationRequest request = new ScoreCalculationRequest(scoreData);
+        
+        ScoreCalculationResponse response = service.calculate(request);
+        assertEquals(1400, response.totalScore());
+        assertEquals("A", response.rank());
+    }
+
+    // [EN] Test rank calculation: score 900-1399 should be rank B.
+    // [JA] テスト: スコア900～1399はランク B
+    @Test
+    void shouldCalculateRankB() {
+        var judgments = new com.happykaratesoup.backend.score.model.Judgments(9, 0, 0, 11);
+        var scoreData = new com.happykaratesoup.backend.score.model.ScoreData(0, judgments);
+        ScoreCalculationRequest request = new ScoreCalculationRequest(scoreData);
+        
+        ScoreCalculationResponse response = service.calculate(request);
+        assertEquals(900, response.totalScore());
+        assertEquals("B", response.rank());
+    }
+
+    // [EN] Test rank calculation: score below 900 should be rank C.
+    // [JA] テスト: スコア900未満はランク C
+    @Test
+    void shouldCalculateRankC() {
+        var judgments = new com.happykaratesoup.backend.score.model.Judgments(5, 0, 0, 15);
+        var scoreData = new com.happykaratesoup.backend.score.model.ScoreData(0, judgments);
+        ScoreCalculationRequest request = new ScoreCalculationRequest(scoreData);
+        
+        ScoreCalculationResponse response = service.calculate(request);
+        assertEquals(500, response.totalScore());
+        assertEquals("C", response.rank());
     }
 }
 


### PR DESCRIPTION
- スコア計算にコンボボーナス追加（最大コンボ数 × 10点）
- ランク判定ロジック実装：S（1800点以上）、A（1400点以上）、B（900点以上）、C（900点未満）
- リザルト画面でランク動的表示
- バックエンド API レスポンスに rank フィールド追加
- テスト期待値をコンボボーナス含む計算に更新