### PR TITLE
iPhoneとWebの接続フローを実装しQR連携で自動遷移対応

### DIFF
--- a/apps/ios-controller/QRCodeReader/QRCodeReader.xcodeproj/project.pbxproj
+++ b/apps/ios-controller/QRCodeReader/QRCodeReader.xcodeproj/project.pbxproj
@@ -398,7 +398,10 @@
 				DEVELOPMENT_TEAM = 29K442P9F7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoads = YES;
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "QRコードを読み取るためにカメラを使用します。";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "同じWi-Fi上のPCに接続してゲームコントローラとして動作するために使用します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -427,7 +430,10 @@
 				DEVELOPMENT_TEAM = 29K442P9F7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoads = YES;
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "QRコードを読み取るためにカメラを使用します。";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "同じWi-Fi上のPCに接続してゲームコントローラとして動作するために使用します。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/apps/ios-controller/QRCodeReader/QRCodeReader/ContentView.swift
+++ b/apps/ios-controller/QRCodeReader/QRCodeReader/ContentView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import AVFoundation
 import UIKit
+import Foundation
 
 private enum CameraAuthorizationState {
     case notDetermined
@@ -52,6 +53,7 @@ struct ContentView: View {
                 QRScannerView(isScanning: $isScanning) { code in
                     scannedCode = code
                     isScanning = false
+                    notifyRoomJoinedIfPossible(from: code)
                     isControllerPresented = true
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 16))
@@ -145,6 +147,39 @@ struct ContentView: View {
         default:
             cameraAuthorization = .denied
         }
+    }
+
+    // [EN] Parses roomId from scanned QR and notifies backend join endpoint.
+    // [JA] 読み取った QR から roomId を解析し、バックエンドの join エンドポイントへ通知します。
+    private func notifyRoomJoinedIfPossible(from scannedValue: String) {
+        guard let components = URLComponents(string: scannedValue),
+              let roomId = components.queryItems?.first(where: { $0.name == "roomId" })?.value,
+              !roomId.isEmpty else {
+            return
+        }
+
+                let apiBase = components.queryItems?
+                        .first(where: { $0.name == "apiBase" })?
+                        .value?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+                let resolvedBaseUrl = (apiBase?.isEmpty == false ? apiBase! : "http://localhost:8080")
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        guard let encodedRoomId = roomId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+                            let url = URL(string: "\(resolvedBaseUrl)/api/controller/rooms/\(encodedRoomId)/join") else {
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { _, _, error in
+            if let error {
+                print("Failed to notify room join: \(error.localizedDescription)")
+            }
+        }.resume()
     }
 }
 

--- a/apps/web/backend-java/src/main/java/com/happysoup/backend/controller/ControllerRoomController.java
+++ b/apps/web/backend-java/src/main/java/com/happysoup/backend/controller/ControllerRoomController.java
@@ -1,0 +1,47 @@
+package com.happysoup.backend.controller;
+
+import com.happysoup.backend.service.ControllerRoomService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+// [EN] Endpoints for web-controller pairing state.
+// [JA] Web とコントローラのペアリング状態を扱うエンドポイントです。
+@RestController
+@RequestMapping("/api/controller/rooms")
+public class ControllerRoomController {
+
+    private final ControllerRoomService controllerRoomService;
+
+    public ControllerRoomController(ControllerRoomService controllerRoomService) {
+        this.controllerRoomService = controllerRoomService;
+    }
+
+    // [EN] Web side registers room before showing QR.
+    // [JA] Web 側が QR 表示前に部屋を登録します。
+    @PostMapping("/{roomId}/register")
+    public Map<String, Object> registerRoom(@PathVariable String roomId) {
+        controllerRoomService.registerRoom(roomId);
+        return Map.of("roomId", roomId, "connected", false);
+    }
+
+    // [EN] iOS side notifies that controller joined this room.
+    // [JA] iOS 側がこの部屋に接続したことを通知します。
+    @PostMapping("/{roomId}/join")
+    public Map<String, Object> joinRoom(@PathVariable String roomId) {
+        controllerRoomService.joinRoom(roomId);
+        return Map.of("roomId", roomId, "connected", true);
+    }
+
+    // [EN] Web side polls room connection state.
+    // [JA] Web 側が部屋の接続状態をポーリング取得します。
+    @GetMapping("/{roomId}/status")
+    public Map<String, Object> getRoomStatus(@PathVariable String roomId) {
+        boolean connected = controllerRoomService.isRoomConnected(roomId);
+        return Map.of("roomId", roomId, "connected", connected);
+    }
+}

--- a/apps/web/backend-java/src/main/java/com/happysoup/backend/service/ControllerRoomService.java
+++ b/apps/web/backend-java/src/main/java/com/happysoup/backend/service/ControllerRoomService.java
@@ -1,0 +1,32 @@
+package com.happysoup.backend.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+// [EN] In-memory room state store for controller pairing.
+// [JA] コントローラ接続ペアリング用のインメモリ部屋状態ストアです。
+@Service
+public class ControllerRoomService {
+
+    private final Map<String, Boolean> roomConnectionStates = new ConcurrentHashMap<>();
+
+    // [EN] Creates/reset a room as disconnected.
+    // [JA] 部屋を未接続状態で作成/初期化します。
+    public void registerRoom(String roomId) {
+        roomConnectionStates.put(roomId, false);
+    }
+
+    // [EN] Marks room as connected from controller side.
+    // [JA] コントローラ側から部屋を接続済みにします。
+    public void joinRoom(String roomId) {
+        roomConnectionStates.put(roomId, true);
+    }
+
+    // [EN] Returns current room connection state.
+    // [JA] 現在の部屋接続状態を返します。
+    public boolean isRoomConnected(String roomId) {
+        return roomConnectionStates.getOrDefault(roomId, false);
+    }
+}

--- a/apps/web/backend-java/src/main/resources/application.yml
+++ b/apps/web/backend-java/src/main/resources/application.yml
@@ -16,4 +16,4 @@ gemini:
 
 app:
   cors:
-    allowed-origins: http://localhost:5173
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:5173}

--- a/apps/web/src/api/controllerRoomApi.ts
+++ b/apps/web/src/api/controllerRoomApi.ts
@@ -1,0 +1,31 @@
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080').replace(/\/$/, '');
+
+export type RoomStatusResponse = {
+  roomId: string;
+  connected: boolean;
+};
+
+export const registerControllerRoom = async (roomId: string): Promise<RoomStatusResponse> => {
+  const response = await fetch(`${API_BASE_URL}/api/controller/rooms/${encodeURIComponent(roomId)}/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to register room (status: ${response.status})`);
+  }
+
+  return (await response.json()) as RoomStatusResponse;
+};
+
+export const fetchControllerRoomStatus = async (roomId: string): Promise<RoomStatusResponse> => {
+  const response = await fetch(`${API_BASE_URL}/api/controller/rooms/${encodeURIComponent(roomId)}/status`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch room status (status: ${response.status})`);
+  }
+
+  return (await response.json()) as RoomStatusResponse;
+};

--- a/apps/web/src/pages/Connect.tsx
+++ b/apps/web/src/pages/Connect.tsx
@@ -1,9 +1,20 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { QRCodeSVG } from 'qrcode.react';
+import { fetchControllerRoomStatus, registerControllerRoom } from '../api/controllerRoomApi';
 
 export default function Connect() {
   const [roomId, setRoomId] = useState('');
+  const navigate = useNavigate();
+  const controllerApiBase = (import.meta.env.VITE_API_BASE_URL ?? `${window.location.protocol}//${window.location.hostname}:8080`).replace(/\/$/, '');
+  const isApiBaseLocalhost = (() => {
+    try {
+      return new URL(controllerApiBase).hostname === 'localhost';
+    } catch {
+      return controllerApiBase.includes('localhost');
+    }
+  })();
 
   useEffect(() => {
     // コンポーネントマウント時にランダムなRoom IDを生成
@@ -12,14 +23,67 @@ export default function Connect() {
     setRoomId(`room-${randomId}`);
   }, []);
 
+  useEffect(() => {
+    if (!roomId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const setupAndWatchRoom = async () => {
+      try {
+        await registerControllerRoom(roomId);
+      } catch (error) {
+        console.error('Failed to register room:', error);
+      }
+
+      const intervalId = window.setInterval(async () => {
+        if (cancelled) {
+          return;
+        }
+
+        try {
+          const status = await fetchControllerRoomStatus(roomId);
+          if (status.connected) {
+            window.clearInterval(intervalId);
+            if (!cancelled) {
+              navigate('/select');
+            }
+          }
+        } catch (error) {
+          console.error('Failed to poll room status:', error);
+        }
+      }, 1000);
+
+      return intervalId;
+    };
+
+    let activeIntervalId: number | undefined;
+    void setupAndWatchRoom().then((intervalId) => {
+      activeIntervalId = intervalId;
+    });
+
+    return () => {
+      cancelled = true;
+      if (activeIntervalId !== undefined) {
+        window.clearInterval(activeIntervalId);
+      }
+    };
+  }, [roomId, navigate]);
+
   // iOSアプリが読み取る想定のQRコード文字列
   // アプリ側で "happykaratesoup", "roomId" などを利用して判定できる形にする
-  const qrCodeValue = `happykaratesoup://connect?roomId=${roomId}`;
+  const qrCodeValue = `happykaratesoup://connect?roomId=${encodeURIComponent(roomId)}&apiBase=${encodeURIComponent(controllerApiBase)}`;
 
   return (
     <div style={{ textAlign: 'center', padding: '50px' }}>
       <h2>コントローラー接続画面</h2>
       <p>iPhoneでQRを読み取って参戦せよ！</p>
+      {isApiBaseLocalhost && (
+        <p style={{ color: '#d32f2f' }}>
+          実機接続時は API 接続先を localhost 以外にしてください（例: VITE_API_BASE_URL=http://192.168.144.187:8080）。
+        </p>
+      )}
 
       {roomId ? (
         <div style={{ 


### PR DESCRIPTION
- Web接続画面でroom登録と接続状態ポーリングを実装
- QRコードに roomId と API接続先(apiBase) を埋め込むよう変更
- iPhoneアプリでQR読み取り後に room join API を通知
- backend-javaに controller room 管理APIを追加（register/join/status）
- room接続状態を保持するサービスを追加しWeb自動遷移を実現
- 実機通信向けにiOSのローカルネットワーク/ATS許可設定を追加
- CORS設定を環境変数ベース運用に整理し、ローカルIPはコードに固定しない形へ統一