### PR TITLE
iOSコントローラー連携を全面強化しWeb操作と結果画面遷移を改善

### DIFF
--- a/apps/ios-controller/QRCodeReader/QRCodeReader/ContentView.swift
+++ b/apps/ios-controller/QRCodeReader/QRCodeReader/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
     @State private var isScanning = false
     @State private var scannedCode: String = ""
     @State private var isControllerPresented = false
+    @State private var controllerDebugMessage: String = ""
 
     var body: some View {
         VStack(spacing: 16) {
@@ -37,11 +38,22 @@ struct ContentView: View {
         .padding()
         .onAppear(perform: requestCameraAccessIfNeeded)
         .fullScreenCover(isPresented: $isControllerPresented) {
-            ControllerView(scannedCode: scannedCode) {
-                scannedCode = ""
-                isScanning = true
-                isControllerPresented = false
-            }
+            ControllerView(
+                scannedCode: scannedCode,
+                debugMessage: controllerDebugMessage,
+                onDirection: { direction in
+                    sendControlCommand(direction, from: scannedCode)
+                },
+                onConfirm: {
+                    sendControlCommand("confirm", from: scannedCode)
+                },
+                onClose: {
+                    scannedCode = ""
+                    controllerDebugMessage = ""
+                    isScanning = true
+                    isControllerPresented = false
+                }
+            )
         }
     }
 
@@ -175,9 +187,59 @@ struct ContentView: View {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        URLSession.shared.dataTask(with: request) { _, _, error in
+        URLSession.shared.dataTask(with: request) { _, response, error in
             if let error {
-                print("Failed to notify room join: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    controllerDebugMessage = "join failed: \(error.localizedDescription)"
+                }
+                return
+            }
+
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            DispatchQueue.main.async {
+                controllerDebugMessage = "join status: \(statusCode)"
+            }
+        }.resume()
+    }
+
+    // [EN] Sends controller button command to backend for room control.
+    // [JA] コントローラのボタン入力コマンドを部屋制御用バックエンドへ送信します。
+    private func sendControlCommand(_ command: String, from scannedValue: String) {
+        guard let components = URLComponents(string: scannedValue),
+              let roomId = components.queryItems?.first(where: { $0.name == "roomId" })?.value,
+              !roomId.isEmpty else {
+            return
+        }
+
+        let apiBase = components.queryItems?
+            .first(where: { $0.name == "apiBase" })?
+            .value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let resolvedBaseUrl = (apiBase?.isEmpty == false ? apiBase! : "http://localhost:8080")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        guard let encodedRoomId = roomId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let encodedCommand = command.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let url = URL(string: "\(resolvedBaseUrl)/api/controller/rooms/\(encodedRoomId)/commands/\(encodedCommand)") else {
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { _, response, error in
+            if let error {
+                DispatchQueue.main.async {
+                    controllerDebugMessage = "cmd \(command): failed (\(error.localizedDescription))"
+                }
+                return
+            }
+
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            DispatchQueue.main.async {
+                controllerDebugMessage = "cmd \(command): status \(statusCode)"
             }
         }.resume()
     }
@@ -298,7 +360,17 @@ final class PreviewView: UIView {
 }
 
 private struct ControllerView: View {
+    enum Direction {
+        case up
+        case down
+        case left
+        case right
+    }
+
     let scannedCode: String
+    let debugMessage: String
+    var onDirection: (String) -> Void
+    var onConfirm: () -> Void
     var onClose: () -> Void
 
     var body: some View {
@@ -338,16 +410,36 @@ private struct ControllerView: View {
                         .truncationMode(.middle)
                 }
 
+                    if !debugMessage.isEmpty {
+                        Text(debugMessage)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.white.opacity(0.92))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(.black.opacity(0.35))
+                        .clipShape(Capsule())
+                    }
+
                 Spacer()
 
                 VStack(spacing: 18) {
-                    PadButton(symbol: "chevron.up", tint: .cyan)
-                    HStack(spacing: 18) {
-                        PadButton(symbol: "chevron.left", tint: .orange)
-                        PadButton(title: "決定", tint: .pink, diameter: 110)
-                        PadButton(symbol: "chevron.right", tint: .orange)
+                    PadButton(symbol: "chevron.up", tint: .cyan) {
+                        onDirection("up")
                     }
-                    PadButton(symbol: "chevron.down", tint: .cyan)
+                    HStack(spacing: 18) {
+                        PadButton(symbol: "chevron.left", tint: .orange) {
+                            onDirection("left")
+                        }
+                        PadButton(title: "決定", tint: .pink, diameter: 110) {
+                            onConfirm()
+                        }
+                        PadButton(symbol: "chevron.right", tint: .orange) {
+                            onDirection("right")
+                        }
+                    }
+                    PadButton(symbol: "chevron.down", tint: .cyan) {
+                        onDirection("down")
+                    }
                 }
 
                 Spacer()
@@ -366,9 +458,10 @@ private struct PadButton: View {
     var title: String? = nil
     var tint: Color
     var diameter: CGFloat = 88
+    var action: () -> Void
 
     var body: some View {
-        Button(action: {}) {
+        Button(action: action) {
             Circle()
                 .fill(
                     LinearGradient(

--- a/apps/web/backend-java/.env.local.example
+++ b/apps/web/backend-java/.env.local.example
@@ -1,0 +1,13 @@
+# Copy this file to .env.local and adjust values for your machine.
+# .env.local is ignored by git.
+
+# Enable Vertex AI mode
+GEMINI_USE_VERTEX_AI=true
+GEMINI_PROJECT_ID=happy-happy-karate-soup
+GEMINI_LOCATION=us-central1
+
+# Path to your service account key file (outside src/, not committed)
+GOOGLE_APPLICATION_CREDENTIALS=/Users/<your-user>/Kaya/HappyHappyKarateSoup/apps/web/backend-java/.secrets/vertex-ai-key.json
+
+# Allow local frontend origins
+APP_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://192.168.144.187:5173

--- a/apps/web/backend-java/README.md
+++ b/apps/web/backend-java/README.md
@@ -193,11 +193,19 @@ apps/web/backend-java/
   - 依存解決や設定不備の初期検知に利用。
 
 ## セットアップ
-1. `.env.example` を参考に環境変数を設定
-2. ルート: [apps/web/backend-java](.)
+1. `.env.local.example` を `.env.local` にコピーして値を設定
+2. ルート: `apps/web/backend-java`
 3. 起動:
-   - `./gradlew bootRun`（Gradle Wrapper追加後）
-   - または `gradle bootRun`
+   - `bash scripts/run_dev_backend.sh`
+
+### 起動時の注意
+- `bash scripts/run_dev_backend.sh` は `.env` と `.env.local` を自動読込します。
+- `GEMINI_USE_VERTEX_AI=true` の場合、以下が未設定だと起動時にエラーで停止します。
+  - `GEMINI_PROJECT_ID`
+  - `GEMINI_LOCATION`
+  - `GOOGLE_APPLICATION_CREDENTIALS`
+- 手動で起動する場合は Maven の明示指定を使ってください。
+  - `mvn org.springframework.boot:spring-boot-maven-plugin:3.4.3:run`
 
 ## POSTテスト結果をファイルへ保存する
 

--- a/apps/web/backend-java/scripts/run_dev_backend.sh
+++ b/apps/web/backend-java/scripts/run_dev_backend.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PORT="${BACKEND_PORT:-8080}"
+KILL_PORT_CONFLICT=false
+
+if [[ "${1:-}" == "--kill-port" ]]; then
+  KILL_PORT_CONFLICT=true
+fi
+
+cd "$PROJECT_DIR"
+
+# Load env files automatically for local development.
+# .env is loaded first, then .env.local overrides values.
+if [[ -f ".env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source ".env"
+  set +a
+fi
+
+if [[ -f ".env.local" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source ".env.local"
+  set +a
+fi
+
+if [[ "${GEMINI_USE_VERTEX_AI:-true}" == "true" ]]; then
+  : "${GEMINI_PROJECT_ID:?GEMINI_PROJECT_ID is required when GEMINI_USE_VERTEX_AI=true}"
+  : "${GEMINI_LOCATION:?GEMINI_LOCATION is required when GEMINI_USE_VERTEX_AI=true}"
+  : "${GOOGLE_APPLICATION_CREDENTIALS:?GOOGLE_APPLICATION_CREDENTIALS is required when GEMINI_USE_VERTEX_AI=true}"
+fi
+
+LISTEN_PID="$(lsof -ti :"$PORT" -sTCP:LISTEN || true)"
+if [[ -n "$LISTEN_PID" ]]; then
+  if [[ "$KILL_PORT_CONFLICT" == "true" ]]; then
+    echo "[run_dev_backend] Port $PORT is in use by PID $LISTEN_PID. Killing it..."
+    kill "$LISTEN_PID"
+    sleep 1
+  else
+    echo "[run_dev_backend] Port $PORT is already in use by PID $LISTEN_PID."
+    echo "[run_dev_backend] Stop it first or run: bash scripts/run_dev_backend.sh --kill-port"
+    exit 1
+  fi
+fi
+
+exec mvn org.springframework.boot:spring-boot-maven-plugin:3.4.3:run

--- a/apps/web/backend-java/src/main/java/com/happysoup/backend/config/AppConfig.java
+++ b/apps/web/backend-java/src/main/java/com/happysoup/backend/config/AppConfig.java
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 // [EN] Central configuration for beans such as WebClient and CORS.
 // [JA] WebClient や CORS などの共通設定を定義します。
@@ -20,6 +21,19 @@ import java.util.List;
 public class AppConfig {
 
     private static final int GEMINI_WEBCLIENT_MAX_IN_MEMORY_SIZE = 10 * 1024 * 1024;
+    private static final List<String> DEFAULT_ALLOWED_ORIGIN_PATTERNS = List.of(
+            "http://localhost:*",
+            "http://127.0.0.1:*",
+            "http://192.168.*.*:*",
+            "http://10.*.*.*:*",
+            "http://172.16.*.*:*",
+            "http://172.17.*.*:*",
+            "http://172.18.*.*:*",
+            "http://172.19.*.*:*",
+            "http://172.2*.*.*:*",
+            "http://172.30.*.*:*",
+            "http://172.31.*.*:*"
+    );
 
     // [EN] Creates a WebClient used for Gemini API calls.
     // [JA] Gemini API 呼び出しに利用する WebClient を生成します。
@@ -46,7 +60,16 @@ public class AppConfig {
     @Bean
     public CorsFilter corsFilter(@Value("${app.cors.allowed-origins}") String allowedOrigins) {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOriginPatterns(List.of(allowedOrigins.split(",")));
+        List<String> allowedOriginPatterns = Stream.concat(
+                DEFAULT_ALLOWED_ORIGIN_PATTERNS.stream(),
+                Stream.of(allowedOrigins.split(","))
+                    .map(String::trim)
+                    .filter(origin -> !origin.isEmpty())
+            )
+            .distinct()
+            .toList();
+
+        config.setAllowedOriginPatterns(allowedOriginPatterns);
         config.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/apps/web/backend-java/src/main/java/com/happysoup/backend/controller/ControllerRoomController.java
+++ b/apps/web/backend-java/src/main/java/com/happysoup/backend/controller/ControllerRoomController.java
@@ -26,7 +26,13 @@ public class ControllerRoomController {
     @PostMapping("/{roomId}/register")
     public Map<String, Object> registerRoom(@PathVariable String roomId) {
         controllerRoomService.registerRoom(roomId);
-        return Map.of("roomId", roomId, "connected", false);
+        var roomState = controllerRoomService.getRoomState(roomId);
+        return Map.of(
+                "roomId", roomId,
+                "connected", roomState.connected(),
+                "commandSequence", roomState.commandSequence(),
+                "latestCommand", roomState.latestCommand() == null ? "" : roomState.latestCommand()
+        );
     }
 
     // [EN] iOS side notifies that controller joined this room.
@@ -34,14 +40,38 @@ public class ControllerRoomController {
     @PostMapping("/{roomId}/join")
     public Map<String, Object> joinRoom(@PathVariable String roomId) {
         controllerRoomService.joinRoom(roomId);
-        return Map.of("roomId", roomId, "connected", true);
+        var roomState = controllerRoomService.getRoomState(roomId);
+        return Map.of(
+                "roomId", roomId,
+                "connected", roomState.connected(),
+                "commandSequence", roomState.commandSequence(),
+                "latestCommand", roomState.latestCommand() == null ? "" : roomState.latestCommand()
+        );
+    }
+
+    // [EN] iOS controller posts directional/confirm commands.
+    // [JA] iOS コントローラから方向キー/決定コマンドを送信します。
+    @PostMapping("/{roomId}/commands/{command}")
+    public Map<String, Object> postCommand(@PathVariable String roomId, @PathVariable String command) {
+        var roomState = controllerRoomService.postCommand(roomId, command);
+        return Map.of(
+                "roomId", roomId,
+                "connected", roomState.connected(),
+                "commandSequence", roomState.commandSequence(),
+                "latestCommand", roomState.latestCommand() == null ? "" : roomState.latestCommand()
+        );
     }
 
     // [EN] Web side polls room connection state.
     // [JA] Web 側が部屋の接続状態をポーリング取得します。
     @GetMapping("/{roomId}/status")
     public Map<String, Object> getRoomStatus(@PathVariable String roomId) {
-        boolean connected = controllerRoomService.isRoomConnected(roomId);
-        return Map.of("roomId", roomId, "connected", connected);
+        var roomState = controllerRoomService.getRoomState(roomId);
+        return Map.of(
+                "roomId", roomId,
+                "connected", roomState.connected(),
+                "commandSequence", roomState.commandSequence(),
+                "latestCommand", roomState.latestCommand() == null ? "" : roomState.latestCommand()
+        );
     }
 }

--- a/apps/web/backend-java/src/main/java/com/happysoup/backend/service/ControllerRoomService.java
+++ b/apps/web/backend-java/src/main/java/com/happysoup/backend/service/ControllerRoomService.java
@@ -10,23 +10,43 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 public class ControllerRoomService {
 
-    private final Map<String, Boolean> roomConnectionStates = new ConcurrentHashMap<>();
+    private final Map<String, RoomState> roomStates = new ConcurrentHashMap<>();
+
+    public record RoomState(boolean connected, long commandSequence, String latestCommand) {
+    }
 
     // [EN] Creates/reset a room as disconnected.
     // [JA] 部屋を未接続状態で作成/初期化します。
     public void registerRoom(String roomId) {
-        roomConnectionStates.put(roomId, false);
+        // Keep existing state to avoid race: iOS join may arrive before web register.
+        roomStates.putIfAbsent(roomId, new RoomState(false, 0L, null));
     }
 
     // [EN] Marks room as connected from controller side.
     // [JA] コントローラ側から部屋を接続済みにします。
     public void joinRoom(String roomId) {
-        roomConnectionStates.put(roomId, true);
+        RoomState current = roomStates.getOrDefault(roomId, new RoomState(false, 0L, null));
+        roomStates.put(roomId, new RoomState(true, current.commandSequence(), current.latestCommand()));
     }
 
     // [EN] Returns current room connection state.
     // [JA] 現在の部屋接続状態を返します。
     public boolean isRoomConnected(String roomId) {
-        return roomConnectionStates.getOrDefault(roomId, false);
+        return roomStates.getOrDefault(roomId, new RoomState(false, 0L, null)).connected();
+    }
+
+    // [EN] Stores the latest controller command and increments command sequence.
+    // [JA] コントローラ入力コマンドを保存し、コマンド連番をインクリメントします。
+    public RoomState postCommand(String roomId, String command) {
+        RoomState current = roomStates.getOrDefault(roomId, new RoomState(false, 0L, null));
+        RoomState updated = new RoomState(true, current.commandSequence() + 1, command);
+        roomStates.put(roomId, updated);
+        return updated;
+    }
+
+    // [EN] Returns full room state including latest command information.
+    // [JA] 最新コマンド情報を含む部屋状態を返します。
+    public RoomState getRoomState(String roomId) {
+        return roomStates.getOrDefault(roomId, new RoomState(false, 0L, null));
     }
 }

--- a/apps/web/src/api/controllerRoomApi.ts
+++ b/apps/web/src/api/controllerRoomApi.ts
@@ -3,6 +3,8 @@ const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:808
 export type RoomStatusResponse = {
   roomId: string;
   connected: boolean;
+  commandSequence?: number;
+  latestCommand?: string;
 };
 
 export const registerControllerRoom = async (roomId: string): Promise<RoomStatusResponse> => {

--- a/apps/web/src/pages/Connect.tsx
+++ b/apps/web/src/pages/Connect.tsx
@@ -32,9 +32,25 @@ export default function Connect() {
 
     const setupAndWatchRoom = async () => {
       try {
-        await registerControllerRoom(roomId);
+        const registeredState = await registerControllerRoom(roomId);
+        if (registeredState.connected && !cancelled) {
+          sessionStorage.setItem('connectedRoomId', roomId);
+          navigate('/select', { state: { roomId } });
+          return undefined;
+        }
       } catch (error) {
         console.error('Failed to register room:', error);
+      }
+
+      try {
+        const initialStatus = await fetchControllerRoomStatus(roomId);
+        if (initialStatus.connected && !cancelled) {
+          sessionStorage.setItem('connectedRoomId', roomId);
+          navigate('/select', { state: { roomId } });
+          return undefined;
+        }
+      } catch (error) {
+        console.error('Failed to fetch initial room status:', error);
       }
 
       const intervalId = window.setInterval(async () => {
@@ -47,7 +63,8 @@ export default function Connect() {
           if (status.connected) {
             window.clearInterval(intervalId);
             if (!cancelled) {
-              navigate('/select');
+              sessionStorage.setItem('connectedRoomId', roomId);
+              navigate('/select', { state: { roomId } });
             }
           }
         } catch (error) {

--- a/apps/web/src/pages/Result/Result.tsx
+++ b/apps/web/src/pages/Result/Result.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 // レーダーチャートコンポーネントのインポート
 import FlavorRadarChart from './writeChart.tsx';
 
@@ -9,6 +11,7 @@ import FlavorRadarChart from './writeChart.tsx';
 // |-味の数値6項目  flavor: FlavorProfile;
 // |-コメント  comment: string;
 import type { SoupGenerateResponse } from '../../api/soupApi';
+import { fetchControllerRoomStatus } from '../../api/controllerRoomApi';
 
 type ResultData = SoupGenerateResponse & {
   totalScore?: number;
@@ -25,8 +28,11 @@ type ResultLocationState = { // 生成結果とエラー情報を格納する型
 //スコア今ベタ打ちだからどうにかしないと
 
 export default function Result() {
+  const navigate = useNavigate();
   const location = useLocation(); // ルーティングで渡された状態を取得
   const state = (location.state as ResultLocationState | null) ?? null; //location.stateをResultLocationState型にキャストし、nullの場合はnullを代入
+  const lastCommandSequenceRef = useRef(0);
+  const isSequenceInitializedRef = useRef(false);
 
   // 生成結果の優先順位: 1. stateから取得 2. sessionStorageから取得
   const storedResultData = sessionStorage.getItem('latestResultData');
@@ -44,6 +50,41 @@ export default function Result() {
 
   const comment = result?.comment ?? 'コメントはまだ生成されていません。';
   const imageDataUrl = result?.imageDataUrl ?? '';
+  const connectedRoomId = sessionStorage.getItem('connectedRoomId') ?? '';
+  const isControllerFocusVisible = !!connectedRoomId;
+
+  useEffect(() => {
+    if (!connectedRoomId) {
+      return;
+    }
+
+    const timerId = window.setInterval(async () => {
+      try {
+        const status = await fetchControllerRoomStatus(connectedRoomId);
+        const currentSequence = status.commandSequence ?? 0;
+        const latestCommand = status.latestCommand ?? '';
+
+        if (!isSequenceInitializedRef.current) {
+          lastCommandSequenceRef.current = currentSequence;
+          isSequenceInitializedRef.current = true;
+          return;
+        }
+
+        if (currentSequence > lastCommandSequenceRef.current) {
+          lastCommandSequenceRef.current = currentSequence;
+          if (latestCommand === 'confirm') {
+            navigate('/');
+          }
+        }
+      } catch (error) {
+        console.error('Failed to poll controller command on result page:', error);
+      }
+    }, 250);
+
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, [connectedRoomId, navigate]);
 
   return (
     <div style={{ textAlign: 'center', padding: '50px' }}>
@@ -86,7 +127,18 @@ export default function Result() {
       <div style={{ marginTop: '50px' }}>
         <p>iPhoneのコントローラー（決定）で操作</p>
         <Link to="/">
-          <button style={{ padding: '15px 30px', fontSize: '18px', cursor: 'pointer' }}>
+          <button
+            style={{
+              padding: '15px 30px',
+              fontSize: '18px',
+              cursor: 'pointer',
+              border: isControllerFocusVisible ? '4px solid #42a5f5' : '1px solid #999',
+              backgroundColor: isControllerFocusVisible ? '#e3f2fd' : '#fff',
+              borderRadius: '8px',
+              fontWeight: isControllerFocusVisible ? 'bold' : 'normal',
+              transition: '0.2s'
+            }}
+          >
             ホームに戻る
           </button>
         </Link>

--- a/apps/web/src/pages/SelectIngredient/SelectIngredient.tsx
+++ b/apps/web/src/pages/SelectIngredient/SelectIngredient.tsx
@@ -1,11 +1,31 @@
 // SelectIngredient.tsx
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { useSelectIngredient } from './useSelectIngredient';
 import { FOOD_EMOJIS } from './emojis'; // 追加した絵文字リストもインポート
+import { fetchControllerRoomStatus } from '../../api/controllerRoomApi';
+
+type FocusArea = 'ingredient' | 'add-button' | 'picker-item' | 'confirm-button';
 
 export default function SelectIngredient() {
   // 画面遷移のためのフック
   const navigate = useNavigate();
+  const location = useLocation();
+  const roomIdFromState = (location.state as { roomId?: string } | null)?.roomId;
+  const connectedRoomId = roomIdFromState ?? sessionStorage.getItem('connectedRoomId') ?? '';
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const [focusArea, setFocusArea] = useState<FocusArea>('ingredient');
+  const [pickerFocusedIndex, setPickerFocusedIndex] = useState(0);
+  const focusedIndexRef = useRef(0);
+  const focusAreaRef = useRef<FocusArea>('ingredient');
+  const pickerFocusedIndexRef = useRef(0);
+  const availableItemsRef = useRef<Array<{ id: string; label: string; emoji: string }>>([]);
+  const [latestControllerCommand, setLatestControllerCommand] = useState('');
+  const [latestControllerSequence, setLatestControllerSequence] = useState(0);
+  const lastCommandSequenceRef = useRef(0);
+  const columnCount = 4;
+  const pickerColumnCount = 7;
 
   // 裏側のロジックから必要なデータや関数を取得
   const {
@@ -17,6 +37,229 @@ export default function SelectIngredient() {
     addCustomIngredient,
     isReady
   } = useSelectIngredient();
+
+  useEffect(() => {
+    availableItemsRef.current = availableItems;
+  }, [availableItems]);
+
+  useEffect(() => {
+    focusedIndexRef.current = focusedIndex;
+  }, [focusedIndex]);
+
+  useEffect(() => {
+    focusAreaRef.current = focusArea;
+  }, [focusArea]);
+
+  useEffect(() => {
+    pickerFocusedIndexRef.current = pickerFocusedIndex;
+  }, [pickerFocusedIndex]);
+
+  useEffect(() => {
+    if (availableItems.length === 0) {
+      return;
+    }
+    setFocusedIndex((prev) => Math.min(prev, availableItems.length - 1));
+  }, [availableItems.length]);
+
+  useEffect(() => {
+    // Keep focus valid so the highlight never disappears unexpectedly.
+    if (focusArea === 'confirm-button' && !isReady) {
+      setFocusArea('ingredient');
+      focusAreaRef.current = 'ingredient';
+    }
+
+    if (focusArea === 'picker-item' && !isPickerOpen) {
+      setFocusArea('add-button');
+      focusAreaRef.current = 'add-button';
+    }
+  }, [focusArea, isPickerOpen, isReady]);
+
+  useEffect(() => {
+    if (!connectedRoomId) {
+      return;
+    }
+
+    const applyControllerCommand = (command: string) => {
+      const currentItems = availableItemsRef.current;
+      if (currentItems.length === 0) {
+        return;
+      }
+
+      if (command === 'left' || command === 'right') {
+        if (focusAreaRef.current === 'picker-item') {
+          setPickerFocusedIndex((prev) => {
+            const next = command === 'left'
+              ? Math.max(0, prev - 1)
+              : Math.min(FOOD_EMOJIS.length - 1, prev + 1);
+            pickerFocusedIndexRef.current = next;
+            return next;
+          });
+          return;
+        }
+
+        if (focusAreaRef.current !== 'ingredient') {
+          return;
+        }
+
+        setFocusedIndex((prev) => {
+          const next = command === 'left'
+            ? Math.max(0, prev - 1)
+            : Math.min(currentItems.length - 1, prev + 1);
+          focusedIndexRef.current = next;
+          return next;
+        });
+      }
+
+      if (command === 'up') {
+        if (focusAreaRef.current === 'confirm-button') {
+          if (isPickerOpen) {
+            setFocusArea('picker-item');
+            focusAreaRef.current = 'picker-item';
+          } else {
+            setFocusArea('add-button');
+            focusAreaRef.current = 'add-button';
+          }
+          return;
+        }
+
+        if (focusAreaRef.current === 'picker-item') {
+          setPickerFocusedIndex((prev) => {
+            if (prev - pickerColumnCount >= 0) {
+              const next = prev - pickerColumnCount;
+              pickerFocusedIndexRef.current = next;
+              return next;
+            }
+
+            setFocusArea('add-button');
+            focusAreaRef.current = 'add-button';
+            return prev;
+          });
+          return;
+        }
+
+        if (focusAreaRef.current === 'add-button') {
+          setFocusArea('ingredient');
+          focusAreaRef.current = 'ingredient';
+          return;
+        }
+
+        setFocusedIndex((prev) => {
+          if (prev - columnCount >= 0) {
+            const next = prev - columnCount;
+            focusedIndexRef.current = next;
+            return next;
+          }
+          focusedIndexRef.current = prev;
+          return prev;
+        });
+      }
+
+      if (command === 'down') {
+        if (focusAreaRef.current === 'ingredient') {
+          const nextByRow = focusedIndexRef.current + columnCount;
+          if (nextByRow < currentItems.length) {
+            setFocusedIndex(nextByRow);
+            focusedIndexRef.current = nextByRow;
+            return;
+          }
+
+          setFocusArea('add-button');
+          focusAreaRef.current = 'add-button';
+          return;
+        }
+
+        if (focusAreaRef.current === 'add-button') {
+          if (isPickerOpen) {
+            setFocusArea('picker-item');
+            focusAreaRef.current = 'picker-item';
+            return;
+          }
+
+          setFocusArea('confirm-button');
+          focusAreaRef.current = 'confirm-button';
+          return;
+        }
+
+        if (focusAreaRef.current === 'picker-item') {
+          setPickerFocusedIndex((prev) => {
+            const next = prev + pickerColumnCount;
+            if (next < FOOD_EMOJIS.length) {
+              pickerFocusedIndexRef.current = next;
+              return next;
+            }
+
+            // Reached bottom row: keep current cursor instead of leaving picker.
+            return prev;
+          });
+          return;
+        }
+      }
+
+      if (command === 'confirm') {
+        if (focusAreaRef.current === 'ingredient') {
+          const target = currentItems[focusedIndexRef.current];
+          if (target) {
+            toggleSelection(target.id);
+          }
+          return;
+        }
+
+        if (focusAreaRef.current === 'add-button') {
+          setIsPickerOpen((prev) => {
+            const next = !prev;
+            if (next) {
+              setFocusArea('picker-item');
+              focusAreaRef.current = 'picker-item';
+              setPickerFocusedIndex(0);
+              pickerFocusedIndexRef.current = 0;
+            }
+            return next;
+          });
+          return;
+        }
+
+        if (focusAreaRef.current === 'picker-item') {
+          const target = FOOD_EMOJIS[pickerFocusedIndexRef.current];
+          if (target) {
+            addCustomIngredient(target);
+            setIsPickerOpen(false);
+            setFocusArea('ingredient');
+            focusAreaRef.current = 'ingredient';
+            setFocusedIndex(0);
+            focusedIndexRef.current = 0;
+            setPickerFocusedIndex(0);
+            pickerFocusedIndexRef.current = 0;
+          }
+          return;
+        }
+
+        if (focusAreaRef.current === 'confirm-button' && isReady) {
+          handleComplete();
+        }
+      }
+    };
+
+    const pollTimerId = window.setInterval(async () => {
+      try {
+        const status = await fetchControllerRoomStatus(connectedRoomId);
+        const currentSequence = status.commandSequence ?? 0;
+        const latestCommand = status.latestCommand ?? '';
+        setLatestControllerSequence(currentSequence);
+        setLatestControllerCommand(latestCommand);
+
+        if (currentSequence > lastCommandSequenceRef.current && latestCommand) {
+          lastCommandSequenceRef.current = currentSequence;
+          applyControllerCommand(latestCommand);
+        }
+      } catch (error) {
+        console.error('Failed to poll controller command:', error);
+      }
+    }, 250);
+
+    return () => {
+      window.clearInterval(pollTimerId);
+    };
+  }, [addCustomIngredient, connectedRoomId, isPickerOpen, isReady, setIsPickerOpen, toggleSelection]);
 
   const handleComplete = () => {
     const payloadData = availableItems.filter(item => selectedChar.includes(item.id));
@@ -44,24 +287,36 @@ export default function SelectIngredient() {
     <div style={{ textAlign: 'center', padding: '50px' }}>
       <h2>具材選択画面</h2>
       <p>材料を3つ選んでください（現在: {selectedChar.length}/3）</p>
+      {!!connectedRoomId && (
+        <p style={{ fontSize: '12px', color: '#455a64' }}>
+          Controller room: {connectedRoomId} / seq: {latestControllerSequence} / cmd: {latestControllerCommand || '-'}
+        </p>
+      )}
 
       {/* 具材の表示エリア */}
       <div style={{ display: 'flex', justifyContent: 'center', gap: '20px', margin: '30px 0', flexWrap: 'wrap' }}>
-        {availableItems.map((item) => {
+        {availableItems.map((item, index) => {
           // この具材が選択されているかどうか
           const isSelected = selectedChar.includes(item.id);
           
           return (
             <div
               key={item.id}
-              onClick={() => toggleSelection(item.id)} // クリックで選択・解除
+              onClick={() => {
+                setFocusArea('ingredient');
+                toggleSelection(item.id);
+              }} // クリックで選択・解除
               style={{
                 padding: '20px',
-                border: isSelected ? '5px solid #ff9800' : '2px solid #ccc',
+                border: isSelected
+                  ? '5px solid #ff9800'
+                  : focusArea === 'ingredient' && focusedIndex === index
+                    ? '4px solid #42a5f5'
+                    : '2px solid #ccc',
                 borderRadius: '10px',
                 cursor: 'pointer',
                 fontWeight: isSelected ? 'bold' : 'normal',
-                backgroundColor: isSelected ? '#fff3e0' : 'transparent',
+                backgroundColor: isSelected ? '#fff3e0' : focusArea === 'ingredient' && focusedIndex === index ? '#e3f2fd' : 'transparent',
                 minWidth: '120px',
                 transition: '0.2s' // フワッと枠線が変わるアニメーション
               }}
@@ -77,8 +332,17 @@ export default function SelectIngredient() {
       {/* さらに具材を選択するボタン */}
       <div style={{ margin: '30px 0' }}>
          <button
-            onClick={() => setIsPickerOpen(!isPickerOpen)}
-            style={{ padding: '10px 20px', cursor: 'pointer', borderRadius: '20px', backgroundColor: '#e0e0e0', border: 'none' }}
+            onClick={() => {
+            setFocusArea('add-button');
+              setIsPickerOpen(!isPickerOpen);
+          }}
+          style={{
+            padding: '10px 20px',
+            cursor: 'pointer',
+            borderRadius: '20px',
+            backgroundColor: focusArea === 'add-button' ? '#d1ecff' : '#e0e0e0',
+            border: focusArea === 'add-button' ? '3px solid #42a5f5' : 'none'
+          }}
          >
             ＋ さらに具材を選択
          </button>
@@ -90,12 +354,33 @@ export default function SelectIngredient() {
           <p style={{ marginTop: '0' }}>追加する絵文字を選んでね</p>
           <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', justifyContent: 'center' }}>
             
-            {FOOD_EMOJIS.map(food => (
+            {FOOD_EMOJIS.map((food, index) => (
               <span
                 key={food.emoji} 
-                onClick={() => addCustomIngredient(food)}  // クリックで具材追加
+                onClick={() => {
+                  setFocusArea('picker-item');
+                  setPickerFocusedIndex(index);
+                  pickerFocusedIndexRef.current = index;
+                  addCustomIngredient(food);
+                  setIsPickerOpen(false);
+                  setFocusArea('ingredient');
+                  focusAreaRef.current = 'ingredient';
+                  setFocusedIndex(0);
+                  focusedIndexRef.current = 0;
+                }}  // クリックで具材追加
                 
-                style={{ fontSize: '30px', cursor: 'pointer', padding: '5px', border: '1px solid #ccc', borderRadius: '5px', backgroundColor: 'white' }}
+                style={{
+                  fontSize: '30px',
+                  cursor: 'pointer',
+                  padding: '5px',
+                  border: focusArea === 'picker-item' && pickerFocusedIndex === index
+                    ? '3px solid #42a5f5'
+                    : '1px solid #ccc',
+                  borderRadius: '5px',
+                  backgroundColor: focusArea === 'picker-item' && pickerFocusedIndex === index
+                    ? '#e3f2fd'
+                    : 'white'
+                }}
               >
                 {food.emoji} 
               </span>
@@ -109,8 +394,20 @@ export default function SelectIngredient() {
       <div style={{ marginTop: '50px' }}>
         {isReady ? (
           <button 
-            onClick={handleComplete} // クリックで選択完了の処理を実行
-            style={{ padding: '15px 30px', fontSize: '18px', cursor: 'pointer', backgroundColor: '#2196f3', color: '#fff', border: 'none', borderRadius: '5px', fontWeight: 'bold' }}
+            onClick={() => {
+              setFocusArea('confirm-button');
+              handleComplete();
+            }} // クリックで選択完了の処理を実行
+            style={{
+              padding: '15px 30px',
+              fontSize: '18px',
+              cursor: 'pointer',
+              backgroundColor: '#2196f3',
+              color: '#fff',
+              border: focusArea === 'confirm-button' ? '3px solid #fff59d' : 'none',
+              borderRadius: '5px',
+              fontWeight: 'bold'
+            }}
             >
             決定（ゲームへ）
           </button>


### PR DESCRIPTION
- iOS: QR読み取り後のjoin/command送信処理を強化し、送信結果のデバッグ表示を追加

- Web接続: room登録・状態監視の取りこぼしを減らし、接続後の具材選択画面遷移を安定化

- Web具材選択: controllerコマンド受信ロジックを再設計し、左右移動・上下遷移・決定動作を領域別に最適化

- Web具材選択: 追加具材ピッカー内のカーソル移動を境界付きに修正し、追加後に先頭カーソルへ復帰する挙動を実装

- Web結果画面: controllerの決定操作でホーム遷移可能にし、ホームボタンにフォーカス枠を表示

- Backend(room API): register/join競合時の状態上書きを防止し、コマンドシーケンス応答を一貫化

- Backend(CORS/起動): LAN開発向けCORS許可を改善し、.env.local自動読込の開発起動スクリプトを追加

- ドキュメント: backend READMEに新しい起動手順と環境変数要件を追記