### PR TITLE
リモコン画面の遷移

### DIFF
--- a/apps/ios-controller/QRCodeReader/QRCodeReader/ContentView.swift
+++ b/apps/ios-controller/QRCodeReader/QRCodeReader/ContentView.swift
@@ -5,10 +5,10 @@
 //  Created by 北田果耶 on 2026/03/14.
 //
 
-import SwiftUI
 import AVFoundation
-import UIKit
 import Foundation
+import SwiftUI
+import UIKit
 
 private enum CameraAuthorizationState {
     case notDetermined
@@ -165,21 +165,25 @@ struct ContentView: View {
     // [JA] 読み取った QR から roomId を解析し、バックエンドの join エンドポイントへ通知します。
     private func notifyRoomJoinedIfPossible(from scannedValue: String) {
         guard let components = URLComponents(string: scannedValue),
-              let roomId = components.queryItems?.first(where: { $0.name == "roomId" })?.value,
-              !roomId.isEmpty else {
+            let roomId = components.queryItems?.first(where: { $0.name == "roomId" })?.value,
+            !roomId.isEmpty
+        else {
             return
         }
 
-                let apiBase = components.queryItems?
-                        .first(where: { $0.name == "apiBase" })?
-                        .value?
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiBase = components.queryItems?
+            .first(where: { $0.name == "apiBase" })?
+            .value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
-                let resolvedBaseUrl = (apiBase?.isEmpty == false ? apiBase! : "http://localhost:8080")
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let resolvedBaseUrl = (apiBase?.isEmpty == false ? apiBase! : "http://localhost:8080")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 
-        guard let encodedRoomId = roomId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-                            let url = URL(string: "\(resolvedBaseUrl)/api/controller/rooms/\(encodedRoomId)/join") else {
+        guard
+            let encodedRoomId = roomId.addingPercentEncoding(
+                withAllowedCharacters: .urlPathAllowed),
+            let url = URL(string: "\(resolvedBaseUrl)/api/controller/rooms/\(encodedRoomId)/join")
+        else {
             return
         }
 
@@ -206,8 +210,9 @@ struct ContentView: View {
     // [JA] コントローラのボタン入力コマンドを部屋制御用バックエンドへ送信します。
     private func sendControlCommand(_ command: String, from scannedValue: String) {
         guard let components = URLComponents(string: scannedValue),
-              let roomId = components.queryItems?.first(where: { $0.name == "roomId" })?.value,
-              !roomId.isEmpty else {
+            let roomId = components.queryItems?.first(where: { $0.name == "roomId" })?.value,
+            !roomId.isEmpty
+        else {
             return
         }
 
@@ -219,9 +224,16 @@ struct ContentView: View {
         let resolvedBaseUrl = (apiBase?.isEmpty == false ? apiBase! : "http://localhost:8080")
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 
-        guard let encodedRoomId = roomId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-              let encodedCommand = command.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-              let url = URL(string: "\(resolvedBaseUrl)/api/controller/rooms/\(encodedRoomId)/commands/\(encodedCommand)") else {
+        guard
+            let encodedRoomId = roomId.addingPercentEncoding(
+                withAllowedCharacters: .urlPathAllowed),
+            let encodedCommand = command.addingPercentEncoding(
+                withAllowedCharacters: .urlPathAllowed),
+            let url = URL(
+                string:
+                    "\(resolvedBaseUrl)/api/controller/rooms/\(encodedRoomId)/commands/\(encodedCommand)"
+            )
+        else {
             return
         }
 
@@ -232,7 +244,8 @@ struct ContentView: View {
         URLSession.shared.dataTask(with: request) { _, response, error in
             if let error {
                 DispatchQueue.main.async {
-                    controllerDebugMessage = "cmd \(command): failed (\(error.localizedDescription))"
+                    controllerDebugMessage =
+                        "cmd \(command): failed (\(error.localizedDescription))"
                 }
                 return
             }
@@ -329,13 +342,17 @@ final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         }
     }
 
-    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+    func metadataOutput(
+        _ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
         guard isScanning, !didFindCode else { return }
 
         for object in metadataObjects {
             guard let readable = object as? AVMetadataMachineReadableCodeObject,
-                  readable.type == .qr,
-                  let value = readable.stringValue else { continue }
+                readable.type == .qr,
+                let value = readable.stringValue
+            else { continue }
 
             didFindCode = true
             onCodeFound(value)
@@ -367,11 +384,27 @@ private struct ControllerView: View {
         case right
     }
 
+    private enum ControllerMode {
+        case remote
+        case action
+    }
+
+    private struct RoomStatusResponse: Decodable {
+        let roomId: String
+        let connected: Bool
+        let commandSequence: Int?
+        let latestCommand: String?
+    }
+
     let scannedCode: String
     let debugMessage: String
     var onDirection: (String) -> Void
     var onConfirm: () -> Void
     var onClose: () -> Void
+
+    @State private var mode: ControllerMode = .remote
+    @State private var pollTask: Task<Void, Never>? = nil
+    @State private var lastSeenSequence: Int = -1
 
     var body: some View {
         ZStack {
@@ -379,7 +412,7 @@ private struct ControllerView: View {
                 colors: [
                     Color(red: 0.05, green: 0.07, blue: 0.14),
                     Color(red: 0.08, green: 0.02, blue: 0.16),
-                    Color(red: 0.02, green: 0.18, blue: 0.22)
+                    Color(red: 0.02, green: 0.18, blue: 0.22),
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
@@ -410,45 +443,142 @@ private struct ControllerView: View {
                         .truncationMode(.middle)
                 }
 
-                    if !debugMessage.isEmpty {
-                        Text(debugMessage)
+                if !debugMessage.isEmpty {
+                    Text(debugMessage)
                         .font(.caption2.monospaced())
                         .foregroundStyle(.white.opacity(0.92))
                         .padding(.horizontal, 10)
                         .padding(.vertical, 6)
                         .background(.black.opacity(0.35))
                         .clipShape(Capsule())
-                    }
+                }
 
                 Spacer()
 
-                VStack(spacing: 18) {
-                    PadButton(symbol: "chevron.up", tint: .cyan) {
-                        onDirection("up")
+                if mode == .remote {
+                    VStack(spacing: 18) {
+                        PadButton(symbol: "chevron.up", tint: .cyan) {
+                            onDirection("up")
+                        }
+                        HStack(spacing: 18) {
+                            PadButton(symbol: "chevron.left", tint: .orange) {
+                                onDirection("left")
+                            }
+                            PadButton(title: "決定", tint: .pink, diameter: 110) {
+                                onConfirm()
+                            }
+                            PadButton(symbol: "chevron.right", tint: .orange) {
+                                onDirection("right")
+                            }
+                        }
+                        PadButton(symbol: "chevron.down", tint: .cyan) {
+                            onDirection("down")
+                        }
                     }
-                    HStack(spacing: 18) {
-                        PadButton(symbol: "chevron.left", tint: .orange) {
-                            onDirection("left")
+                } else {
+                    VStack(spacing: 18) {
+                        Text("ゲームモード")
+                            .font(.headline)
+                            .foregroundStyle(.white.opacity(0.92))
+
+                        HStack(spacing: 20) {
+                            PadButton(title: "パンチ", tint: .red, diameter: 130) {
+                                onDirection("punch")
+                            }
+                            PadButton(title: "チョップ", tint: .blue, diameter: 130) {
+                                onDirection("chop")
+                            }
                         }
-                        PadButton(title: "決定", tint: .pink, diameter: 110) {
-                            onConfirm()
-                        }
-                        PadButton(symbol: "chevron.right", tint: .orange) {
-                            onDirection("right")
-                        }
-                    }
-                    PadButton(symbol: "chevron.down", tint: .cyan) {
-                        onDirection("down")
                     }
                 }
 
                 Spacer()
 
-                Text("QRコードを読み取り後、コントローラ画面に切り替わりました")
-                    .font(.footnote)
-                    .foregroundStyle(.white.opacity(0.8))
+                Text(
+                    mode == .remote
+                        ? "QRコードを読み取り後、コントローラ画面に切り替わりました"
+                        : "材料選択でゲーム開始すると、パンチ/チョップ画面へ切り替わります"
+                )
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(0.8))
             }
             .padding(20)
+        }
+        .onAppear {
+            startPollingRoomStatus()
+        }
+        .onDisappear {
+            pollTask?.cancel()
+            pollTask = nil
+        }
+    }
+
+    private func startPollingRoomStatus() {
+        pollTask?.cancel()
+
+        guard let roomInfo = parseRoomInfo(from: scannedCode) else {
+            return
+        }
+
+        pollTask = Task {
+            while !Task.isCancelled {
+                await fetchRoomStatus(baseURL: roomInfo.baseURL, roomId: roomInfo.roomId)
+                try? await Task.sleep(nanoseconds: 400_000_000)
+            }
+        }
+    }
+
+    private func parseRoomInfo(from scannedValue: String) -> (baseURL: String, roomId: String)? {
+        guard let components = URLComponents(string: scannedValue),
+            let roomId = components.queryItems?.first(where: { $0.name == "roomId" })?.value,
+            !roomId.isEmpty
+        else {
+            return nil
+        }
+
+        let apiBase = components.queryItems?
+            .first(where: { $0.name == "apiBase" })?
+            .value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let resolvedBaseURL = (apiBase?.isEmpty == false ? apiBase! : "http://localhost:8080")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        return (resolvedBaseURL, roomId)
+    }
+
+    @MainActor
+    private func fetchRoomStatus(baseURL: String, roomId: String) async {
+        guard
+            let encodedRoomId = roomId.addingPercentEncoding(
+                withAllowedCharacters: .urlPathAllowed),
+            let url = URL(string: "\(baseURL)/api/controller/rooms/\(encodedRoomId)/status")
+        else {
+            return
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode)
+            else {
+                return
+            }
+
+            let status = try JSONDecoder().decode(RoomStatusResponse.self, from: data)
+            let sequence = status.commandSequence ?? 0
+            let latest = status.latestCommand ?? ""
+
+            if sequence > lastSeenSequence {
+                lastSeenSequence = sequence
+                if latest == "start_game" {
+                    mode = .action
+                } else if latest == "end_game" || latest == "game_end" || latest == "return_remote"
+                {
+                    mode = .remote
+                }
+            }
+        } catch {
+            // keep silent to avoid noisy UI updates during temporary network hiccups
         }
     }
 }

--- a/apps/ios-controller/RemoteController/ControllerWebSocketClient.swift
+++ b/apps/ios-controller/RemoteController/ControllerWebSocketClient.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+// [EN] Lightweight WebSocket client for controller event forwarding.
+// [JA] コントローラーイベント転送用の軽量 WebSocket クライアントです。
+@MainActor
+final class ControllerWebSocketClient: ObservableObject {
+    static let shared = ControllerWebSocketClient()
+
+    @Published private(set) var isConnected: Bool = false
+    @Published private(set) var lastErrorMessage: String?
+    @Published private(set) var lastReceivedMessage: String?
+
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+
+    private init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    // [EN] Connects to WebSocket endpoint. Also accepts http/https and converts to ws/wss.
+    // [JA] WebSocket エンドポイントへ接続します。http/https も ws/wss に変換して受け付けます。
+    func connect(rawURLString: String) {
+        guard let resolvedURL = Self.resolveWebSocketURL(from: rawURLString) else {
+            lastErrorMessage = "Invalid WebSocket URL"
+            return
+        }
+
+        disconnect()
+
+        let newTask = session.webSocketTask(with: resolvedURL)
+        task = newTask
+        newTask.resume()
+        isConnected = true
+        lastErrorMessage = nil
+
+        receiveLoop(task: newTask)
+    }
+
+    // [EN] Disconnects active WebSocket session.
+    // [JA] アクティブな WebSocket セッションを切断します。
+    func disconnect() {
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+        isConnected = false
+    }
+
+    // [EN] Sends already-encoded JSON text.
+    // [JA] エンコード済み JSON 文字列を送信します。
+    func send(jsonText: String) {
+        guard let task else {
+            lastErrorMessage = "WebSocket is not connected"
+            return
+        }
+
+        task.send(.string(jsonText)) { [weak self] error in
+            guard let self else { return }
+            if let error {
+                Task { @MainActor in
+                    self.lastErrorMessage = error.localizedDescription
+                    self.isConnected = false
+                }
+            }
+        }
+    }
+
+    // [EN] Keeps receiving messages to detect closure and keep connection healthy.
+    // [JA] 接続状態の維持と切断検知のために受信ループを継続します。
+    private func receiveLoop(task: URLSessionWebSocketTask) {
+        task.receive { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case let .success(message):
+                Task { @MainActor in
+                    if self.task === task {
+                        switch message {
+                        case let .string(text):
+                            self.lastReceivedMessage = text
+                        case let .data(data):
+                            self.lastReceivedMessage = String(data: data, encoding: .utf8)
+                        @unknown default:
+                            break
+                        }
+                        self.receiveLoop(task: task)
+                    }
+                }
+            case let .failure(error):
+                Task { @MainActor in
+                    if self.task === task {
+                        self.lastErrorMessage = error.localizedDescription
+                        self.isConnected = false
+                        self.task = nil
+                    }
+                }
+            }
+        }
+    }
+
+    private static func resolveWebSocketURL(from raw: String) -> URL? {
+        guard
+            var components = URLComponents(
+                string: raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            return nil
+        }
+
+        switch components.scheme?.lowercased() {
+        case "ws", "wss":
+            break
+        case "http":
+            components.scheme = "ws"
+        case "https":
+            components.scheme = "wss"
+        default:
+            return nil
+        }
+
+        return components.url
+    }
+}

--- a/apps/web/src/api/controllerRoomApi.ts
+++ b/apps/web/src/api/controllerRoomApi.ts
@@ -31,3 +31,21 @@ export const fetchControllerRoomStatus = async (roomId: string): Promise<RoomSta
 
   return (await response.json()) as RoomStatusResponse;
 };
+
+export const postControllerRoomCommand = async (roomId: string, command: string): Promise<RoomStatusResponse> => {
+  const response = await fetch(
+    `${API_BASE_URL}/api/controller/rooms/${encodeURIComponent(roomId)}/commands/${encodeURIComponent(command)}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to post controller command (status: ${response.status})`);
+  }
+
+  return (await response.json()) as RoomStatusResponse;
+};

--- a/apps/web/src/pages/Game/Game.tsx
+++ b/apps/web/src/pages/Game/Game.tsx
@@ -5,6 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { useGameLogic } from './useGameLogic'; // 先ほど作ったフックを読み込む
 import { postSoupGenerate } from '../../api/soupApi';
 import type { SoupGenerateResponse } from '../../api/soupApi';
+import { postControllerRoomCommand } from '../../api/controllerRoomApi';
 
 
 //Zindex ; 背景:0, レールの背景:50, レールの線:60, 絵文字:100, 鍋の画像:10, 判定ゾーン:55
@@ -96,7 +97,7 @@ export default function Game() {
   const hasNavigatedRef = useRef(false);
   const isFinishingRef = useRef(false);
   const retryTimerRef = useRef<number | null>(null);
-  const soupGenerationPromiseRef = useRef<Promise<SoupGenerateResponse> | null>(null);
+  const soupGenerationPromiseRef = useRef<Promise<SoupGenerateResponse | null> | null>(null);
   const soupGenerationResultRef = useRef<SoupGenerateResponse | null>(null);
   // フックから必要な状態を受け取る
   const { phase,
@@ -187,7 +188,7 @@ export default function Game() {
           startSoupGeneration();
         }, 3000);
 
-        throw error;
+        return null;
       })
       .finally(() => {
         setIsImageGenerating(false);
@@ -217,11 +218,6 @@ export default function Game() {
       return;
     }
 
-    if (!soupGenerationResultRef.current) {
-      setGenerationError('画像生成の完了を待っています...');
-      return;
-    }
-
     isFinishingRef.current = true;
     setIsGenerating(true);
     sessionStorage.removeItem('latestSoupResult');
@@ -247,17 +243,33 @@ export default function Game() {
       // [JA] リザルト遷移には生成AI画像を必須とします。
       const generatedSoup = soupGenerationResultRef.current;
 
-      const resultData = {
-        ingredients: generatedSoup.ingredients,
-        imageDataUrl: generatedSoup.imageDataUrl,
-        flavor: generatedSoup.flavor,
-        comment: generatedSoup.comment,
-        totalScore: resolvedTotalScore,
-        rank: resolvedRank, // [EN] Add rank to result. [JA] 結果にランクを追加
-      };
+      const resultData = generatedSoup
+        ? {
+          ingredients: generatedSoup.ingredients,
+          imageDataUrl: generatedSoup.imageDataUrl,
+          flavor: generatedSoup.flavor,
+          comment: generatedSoup.comment,
+          totalScore: resolvedTotalScore,
+          rank: resolvedRank, // [EN] Add rank to result. [JA] 結果にランクを追加
+        }
+        : {
+          ingredients: [],
+          imageDataUrl: '',
+          flavor: 'Unknown',
+          comment: 'No comment available',
+          totalScore: resolvedTotalScore,
+          rank: resolvedRank, // [EN] Add rank to result. [JA] 結果にランクを追加
+        };
 
       sessionStorage.setItem('latestSoupResult', JSON.stringify(resultData));
       sessionStorage.setItem('latestResultData', JSON.stringify(resultData));
+
+      const connectedRoomId = sessionStorage.getItem('connectedRoomId');
+      if (connectedRoomId) {
+        void postControllerRoomCommand(connectedRoomId, 'end_game').catch((error) => {
+          console.error('Failed to notify controller room end_game:', error);
+        });
+      }
 
       hasNavigatedRef.current = true;
       navigate('/result', { state: { generated: resultData } });
@@ -280,12 +292,12 @@ export default function Game() {
   }, [isChartFlowFinished]);
 
   useEffect(() => {
-    if (!isGameFinished || !isImageReady || isGenerating || hasNavigatedRef.current) {
+    if (!isGameFinished || (!isImageReady && !generationError) || isGenerating || hasNavigatedRef.current) {
       return;
     }
 
     void handleFinishGame();
-  }, [isGameFinished, isImageReady, isGenerating]);
+  }, [isGameFinished, isImageReady, generationError, isGenerating]);
 
   return (
     <div style={{ textAlign: 'center', padding: '50px' }}>

--- a/apps/web/src/pages/Game/useGameLogic.ts
+++ b/apps/web/src/pages/Game/useGameLogic.ts
@@ -1,7 +1,7 @@
 // useGameLogic.ts
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Phase, Ingredient, ActionType } from './types';
-import charData from '../../testdatas/demo/charData-demo-60s-01.json'; // 譜面データをインポート
+import charData from '../../testdatas/demo/charData-demo-30s-01.json'; // 譜面データをインポート
 import { useScoreLogic } from './useScoreLogic'; // 分割したスコアロジックをインポート
 
 // 譜面データの型 (バックエンドからのレスポンスを想定)
@@ -123,7 +123,8 @@ export const useGameLogic = (options: UseGameLogicOptions = {}) => {
       // 譜面を取得する（generate_chart で作られたランダム譜面を優先）
       // エラー回避のため、setTimeoutの中にセット処理をまとめる
       setTimeout(() => {
-        setChart(getRandomGeneratedChart());
+        // setChart(getRandomGeneratedChart()); // 本番はこっち
+        setChart(charData as ChartItem[]);
         setPhase('playing'); //譜面切り替えと同時にplayingフェーズに移行
         startTimeRef.current = performance.now(); // 精度の高い開始時間を記録
         chartIndexRef.current = 0; // インデックスをリセット

--- a/apps/web/src/pages/Result/Result.tsx
+++ b/apps/web/src/pages/Result/Result.tsx
@@ -11,7 +11,7 @@ import FlavorRadarChart from './writeChart.tsx';
 // |-味の数値6項目  flavor: FlavorProfile;
 // |-コメント  comment: string;
 import type { SoupGenerateResponse } from '../../api/soupApi';
-import { fetchControllerRoomStatus } from '../../api/controllerRoomApi';
+import { fetchControllerRoomStatus, postControllerRoomCommand } from '../../api/controllerRoomApi';
 
 
 type ResultData = SoupGenerateResponse & {
@@ -31,6 +31,7 @@ export default function Result() {
   const state = (location.state as ResultLocationState | null) ?? null; //location.stateをResultLocationState型にキャストし、nullの場合はnullを代入
   const lastCommandSequenceRef = useRef(0);
   const isSequenceInitializedRef = useRef(false);
+  const hasNotifiedEndGameRef = useRef(false);
 
   // 認証状態を確認
   const isLoggedIn = !!sessionStorage.getItem('authToken');
@@ -53,6 +54,17 @@ export default function Result() {
   const imageDataUrl = result?.imageDataUrl ?? '';
   const connectedRoomId = sessionStorage.getItem('connectedRoomId') ?? '';
   const isControllerFocusVisible = !!connectedRoomId;
+
+  useEffect(() => {
+    if (!connectedRoomId || hasNotifiedEndGameRef.current) {
+      return;
+    }
+
+    hasNotifiedEndGameRef.current = true;
+    void postControllerRoomCommand(connectedRoomId, 'end_game').catch((error) => {
+      console.error('Failed to notify controller room end_game on result page:', error);
+    });
+  }, [connectedRoomId]);
 
   useEffect(() => {
     if (!connectedRoomId) {

--- a/apps/web/src/pages/SelectIngredient/SelectIngredient.tsx
+++ b/apps/web/src/pages/SelectIngredient/SelectIngredient.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { useSelectIngredient } from './useSelectIngredient';
 import { FOOD_EMOJIS } from './emojis'; // 追加した絵文字リストもインポート
-import { fetchControllerRoomStatus } from '../../api/controllerRoomApi';
+import { fetchControllerRoomStatus, postControllerRoomCommand } from '../../api/controllerRoomApi';
 
 type FocusArea = 'ingredient' | 'add-button' | 'picker-item' | 'confirm-button';
 
@@ -278,6 +278,12 @@ export default function SelectIngredient() {
     // }
     // =======================================================
 
+    if (connectedRoomId) {
+      void postControllerRoomCommand(connectedRoomId, 'start_game').catch((error) => {
+        console.error('Failed to notify controller game start:', error);
+      });
+    }
+
     // API通信コード追加後：通信が成功しないと遷移しない
     // 現在は通信無しで遷移
     navigate('/game', { state: { selectedIngredients: payloadData } });
@@ -298,7 +304,7 @@ export default function SelectIngredient() {
         {availableItems.map((item, index) => {
           // この具材が選択されているかどうか
           const isSelected = selectedChar.includes(item.id);
-          
+
           return (
             <div
               key={item.id}
@@ -331,10 +337,10 @@ export default function SelectIngredient() {
 
       {/* さらに具材を選択するボタン */}
       <div style={{ margin: '30px 0' }}>
-         <button
-            onClick={() => {
+        <button
+          onClick={() => {
             setFocusArea('add-button');
-              setIsPickerOpen(!isPickerOpen);
+            setIsPickerOpen(!isPickerOpen);
           }}
           style={{
             padding: '10px 20px',
@@ -343,9 +349,9 @@ export default function SelectIngredient() {
             backgroundColor: focusArea === 'add-button' ? '#d1ecff' : '#e0e0e0',
             border: focusArea === 'add-button' ? '3px solid #42a5f5' : 'none'
           }}
-         >
-            ＋ さらに具材を選択
-         </button>
+        >
+          ＋ さらに具材を選択
+        </button>
       </div>
 
       {/* 絵文字ピッカー（ボタンを押したら出現） */}
@@ -353,10 +359,10 @@ export default function SelectIngredient() {
         <div style={{ padding: '20px', backgroundColor: '#f5f5f5', borderRadius: '10px', display: 'inline-block', maxWidth: '400px' }}>
           <p style={{ marginTop: '0' }}>追加する絵文字を選んでね</p>
           <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', justifyContent: 'center' }}>
-            
+
             {FOOD_EMOJIS.map((food, index) => (
               <span
-                key={food.emoji} 
+                key={food.emoji}
                 onClick={() => {
                   setFocusArea('picker-item');
                   setPickerFocusedIndex(index);
@@ -368,7 +374,7 @@ export default function SelectIngredient() {
                   setFocusedIndex(0);
                   focusedIndexRef.current = 0;
                 }}  // クリックで具材追加
-                
+
                 style={{
                   fontSize: '30px',
                   cursor: 'pointer',
@@ -382,7 +388,7 @@ export default function SelectIngredient() {
                     : 'white'
                 }}
               >
-                {food.emoji} 
+                {food.emoji}
               </span>
             ))}
 
@@ -393,7 +399,7 @@ export default function SelectIngredient() {
       {/* ゲームへ進むボタン（3つ選ぶまで押せない） */}
       <div style={{ marginTop: '50px' }}>
         {isReady ? (
-          <button 
+          <button
             onClick={() => {
               setFocusArea('confirm-button');
               handleComplete();
@@ -408,7 +414,7 @@ export default function SelectIngredient() {
               borderRadius: '5px',
               fontWeight: 'bold'
             }}
-            >
+          >
             決定（ゲームへ）
           </button>
         ) : (


### PR DESCRIPTION
材料選択画面→ゲーム画面時に、リモコンモードからpunch/chopモードの画面に遷移する
ゲーム終了時はリモコンモードの画面に遷移する

その他
譜面はランダムに選んだものを使っているみたいだったが、長いので、一旦30秒のものを使うようにした
chop/punch画面は仮ボタンが作られているが、フロントと連携しているわけでもない