### PR TITLE
タイミング判定を元に戻す

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -49,15 +49,15 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 100dvh;
+  min-height: 100vh;
   background-color: var(--c-slate-100);
   /* Some neutral background behind the app */
 }
 
 #root {
   width: 100%;
-  max-width: 100vw;
-  height: 100dvh;
+  max-width: 1200px;
+  height: 100vh;
   margin: 0 auto;
   text-align: center;
   display: flex;

--- a/apps/web/src/pages/Game/Game.tsx
+++ b/apps/web/src/pages/Game/Game.tsx
@@ -648,7 +648,7 @@ export default function Game() {
                     flexDirection: 'column',
                     alignItems: 'center',
                     transform: isBursting ? 'translate(-50%, -50%)' : undefined,
-                    animation: isBursting ? 'none' : `moveForward ${NOTE_ANIMATION_MS}ms linear forwards`,
+                    animation: isBursting ? 'none' : `moveForward ${NOTE_ANIMATION_MS}ms ease-in forwards`,
                     zIndex: 100,
                     opacity: item.missed ? 0.2 : 1,
                     filter: item.missed ? 'grayscale(100%)' : 'none',

--- a/apps/web/src/pages/Game/timing.ts
+++ b/apps/web/src/pages/Game/timing.ts
@@ -1,0 +1,5 @@
+// Game timing constants shared by render animation and judgment logic.
+export const NOTE_ANIMATION_MS = 3000;
+
+// Empirically tuned lead time for current moveForward perspective animation.
+export const NOTE_SPAWN_LEAD_MS = 2000;


### PR DESCRIPTION
- rootのCSSも変えてしまったので元に戻した
- タイミング判定のロジックを完全に前と同じにした
- パラメータだけtiming.tsに乗せるようになっている