### PR TITLE
iOS: 向き修正

### DIFF
--- a/apps/ios-controller/QRCodeReader/QRCodeReader/QRScannerView.swift
+++ b/apps/ios-controller/QRCodeReader/QRCodeReader/QRScannerView.swift
@@ -41,9 +41,9 @@ final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         view.videoPreviewLayer.session = session
         view.videoPreviewLayer.videoGravity = .resizeAspectFill
         if let previewConnection = view.videoPreviewLayer.connection,
-            previewConnection.isVideoOrientationSupported
+            previewConnection.isVideoRotationAngleSupported(90)
         {
-            previewConnection.videoOrientation = .portrait
+            previewConnection.videoRotationAngle = 90
         }
 
         sessionQueue.async {
@@ -62,9 +62,9 @@ final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
                 self.metadataOutput.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
                 self.metadataOutput.metadataObjectTypes = [.qr]
                 if let metadataConnection = self.metadataOutput.connection(with: .video),
-                    metadataConnection.isVideoOrientationSupported
+                    metadataConnection.isVideoRotationAngleSupported(90)
                 {
-                    metadataConnection.videoOrientation = .portrait
+                    metadataConnection.videoRotationAngle = 90
                 }
             }
 


### PR DESCRIPTION
`AVCaptureConnection` の向き設定を `videoOrientation` から `videoRotationAngle` ベースに変更
`videoRotationAngle` は角度を明示できる新しいAPIで、今後の互換性・可読性の面で有利なためです。  
実装では `isVideoRotationAngleSupported(90)` を確認したうえで `videoRotationAngle = 90` を設定し、サポート外デバイスでの不正設定を防いでいます。