### PR TITLE
テストの時VITE_GOOGLE_CLIENT_IDは必須にしない

### DIFF
--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -60,7 +60,6 @@ jobs:
           APP_GCS_BUCKET_NAME: ${{ secrets.APP_GCS_BUCKET_NAME }}
           APP_GCS_OBJECT_PREFIX: ${{ secrets.APP_GCS_OBJECT_PREFIX }}
           APP_CORS_ALLOWED_ORIGINS: ${{ secrets.APP_CORS_ALLOWED_ORIGINS }}
-          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: |
           set -euo pipefail
           missing=0
@@ -74,14 +73,16 @@ jobs:
             SPRING_DATASOURCE_PASSWORD \
             APP_GCS_BUCKET_NAME \
             APP_GCS_OBJECT_PREFIX \
-            APP_CORS_ALLOWED_ORIGINS \
-            VITE_GOOGLE_CLIENT_ID
+            APP_CORS_ALLOWED_ORIGINS
           do
             if [ -z "${!k:-}" ]; then
               echo "[ERROR] Missing secret: $k" >&2
               missing=1
             fi
           done
+          if [ -z "${VITE_GOOGLE_CLIENT_ID:-}" ]; then
+            echo "[WARN] Missing secret: VITE_GOOGLE_CLIENT_ID (optional)" >&2
+          fi
           if [ "$missing" -ne 0 ]; then
             echo "[HINT] Secrets are not available for workflows triggered from forks/Dependabot. Run from the default branch (main) and configure repo/environment secrets." >&2
             exit 1


### PR DESCRIPTION
VITE_GOOGLE_CLIENT_ID (ゲームのログインに必要なID)を 必須チェックから外して、未設定でもデプロイ続行するようにしました（未設定の場合は WARN だけ出します）。


変更: /Users/sui/gdoc/HappyHappyKarateSoup/.github/workflows/cloudrun-deploy.yml