### PR TITLE
背景画像とロゴのスタイルの修正

### DIFF
--- a/apps/web/src/components/BrandedBackground.tsx
+++ b/apps/web/src/components/BrandedBackground.tsx
@@ -17,11 +17,13 @@ export default function BrandedBackground({
     <div
       style={{
         minHeight: '100dvh',
+        minWidth: '100vw',
         position: 'relative',
         backgroundImage: `url(${bgTitle})`,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundRepeat: 'no-repeat',
+        backgroundColor: '#1a1a1f',
         ...contentStyle,
       }}
     >

--- a/apps/web/src/components/BrandedConnectionBackground.tsx
+++ b/apps/web/src/components/BrandedConnectionBackground.tsx
@@ -11,11 +11,12 @@ export default function BrandedConnectionBackground({ children }: BrandedConnect
     <div
       style={{
         minHeight: '100dvh',
+        minWidth: '100vw',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         backgroundImage: `url(${bgConnection})`,
-        backgroundSize: 'contain',
+        backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundRepeat: 'no-repeat',
         backgroundColor: '#1a1a1f',

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -28,8 +28,17 @@ export default function Home() {
           className="h-10 w-10 rounded-md bg-black/35 p-1 shadow-lg sm:h-12 sm:w-12"
         />
         <span
-          className="font-[var(--f-pixel)] text-[10px] uppercase tracking-wide text-[#f8f1de] drop-shadow sm:text-xs"
-          style={{ textShadow: '2px 2px 0 #1f0e0a' }}
+          style={{
+            color: '#FFF',
+            fontFamily: "'Press Start 2P', monospace",
+            fontSize: '1.2vw',
+            fontWeight: 400,
+            lineHeight: 1.4,
+            letterSpacing: '-0.35px',
+            textTransform: 'uppercase',
+            WebkitTextStrokeWidth: '1.2px',
+            WebkitTextStrokeColor: '#000',
+          }}
         >
           Happy Happy Karate Soup
         </span>


### PR DESCRIPTION
- resultとdifficultページの背景画像がスクリーン画面を覆い尽くすようにする
- homeのロゴを他のページと統一
- 変更前
<img width="291" height="110" alt="スクリーンショット 0008-05-23 10 47 13" src="https://github.com/user-attachments/assets/4fc7b33a-2dc7-44ab-b7cf-6c8e27469df2" />

- 変更後
<img width="553" height="133" alt="スクリーンショット 0008-05-23 10 47 32" src="https://github.com/user-attachments/assets/44eb4e08-740e-45a9-bde9-c0828047cf0a" />
